### PR TITLE
OIL-98 warn about locale string deprecation

### DIFF
--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -32,7 +32,8 @@ function getConfiguration() {
       logInfo('Using default config');
     }
     setGlobalOilObject('CONFIG', readConfiguration(configurationElement));
-    parseServerUrl();
+
+    parseServerUrls();
   }
   return getGlobalOilObject('CONFIG');
 }
@@ -45,10 +46,16 @@ function getConfiguration() {
  * cf. https://webpack.js.org/guides/public-path/
  *
  */
-// FIXME needs testing
-function parseServerUrl() {
-  if (getGlobalOilObject('CONFIG').publicPath) {
-    __webpack_public_path__ = getGlobalOilObject('CONFIG').publicPath;
+function parseServerUrls() {
+  let config = getConfiguration();
+
+  if((typeof config.locale) === 'string' && getLocaleUrl() === undefined) {
+    logError(`locale as a string "${config.locale}" will be deprecated in future versions. Please review documentation.`);
+    setLocaleUrl('https://oil-backend.herokuapp.com/oil/api/userViewLocales/' + getLocaleVariantName());
+  }
+
+  if (getPublicPath()) {
+    __webpack_public_path__ = getPublicPath();
   }
 }
 
@@ -62,6 +69,10 @@ function parseServerUrl() {
 export function getConfigValue(name, defaultValue) {
   let config = getConfiguration();
   return (config && config[name]) ? config[name] : defaultValue;
+}
+
+function setConfigValue(name, value) {
+  getConfiguration()[name] = value;
 }
 
 // **
@@ -88,9 +99,8 @@ export function isSubscriberSetCookieActive() {
 }
 
 /**
- *
- * Get the hub iFrame domain with protocol prefix for the current location
- * @returns {string, null} domain iframe orgin
+ * The server path from which all chunks and ressources will be loaded.
+ * @returns {string, '//oil.axelspringer.com'}
  */
 export function getHubOrigin() {
   let origin = getConfigValue(OIL_CONFIG.ATTR_HUB_ORIGIN, '//oil.axelspringer.com');
@@ -104,8 +114,21 @@ export function getHubPath() {
   return getConfigValue(OIL_CONFIG.ATTR_HUB_PATH, `/release/${OilVersion.getLatestReleaseVersion()}/hub.html`);
 }
 
+/**
+ *
+ * Get the hub iFrame domain with protocol prefix for the current location
+ * @returns {string, null} domain iframe orgin
+ */
+export function getPublicPath() {
+  return getConfigValue(OIL_CONFIG.ATTR_PUBLIC_PATH, undefined);
+}
+
 export function getLocaleUrl() {
   return getConfigValue(OIL_CONFIG.ATTR_LOCALE_URL, undefined);
+}
+
+export function setLocaleUrl(value) {
+  setConfigValue(OIL_CONFIG.ATTR_LOCALE_URL, value);
 }
 
 export function getIabVendorListUrl() {
@@ -192,5 +215,5 @@ export function getLocale() {
 }
 
 export function setLocale(localeObject) {
-  getConfiguration()[OIL_CONFIG.ATTR_LOCALE] = localeObject;
+  setConfigValue(OIL_CONFIG.ATTR_LOCALE, localeObject);
 }

--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -47,7 +47,7 @@ function getConfiguration() {
  *
  */
 function parseServerUrls() {
-  let config = getConfiguration();
+  const config = getConfiguration();
 
   if((typeof config.locale) === 'string' && getLocaleUrl() === undefined) {
     logError(`locale as a string "${config.locale}" will be deprecated in future versions. Please review documentation.`);
@@ -67,7 +67,7 @@ function parseServerUrls() {
  * @returns {*}
  */
 export function getConfigValue(name, defaultValue) {
-  let config = getConfiguration();
+  const config = getConfiguration();
   return (config && config[name]) ? config[name] : defaultValue;
 }
 

--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -126,7 +126,7 @@ export function getLocaleUrl() {
   return getConfigValue(OIL_CONFIG.ATTR_LOCALE_URL, undefined);
 }
 
-export function setLocaleUrl(value) {
+function setLocaleUrl(value) {
   setConfigValue(OIL_CONFIG.ATTR_LOCALE_URL, value);
 }
 

--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -47,10 +47,10 @@ function getConfiguration() {
  *
  */
 function parseServerUrls() {
-  const config = getConfiguration();
+  const localeValue = getLocale();
 
-  if((typeof config.locale) === 'string' && getLocaleUrl() === undefined) {
-    logError(`locale as a string "${config.locale}" will be deprecated in future versions. Please review documentation.`);
+  if((!localeValue || (typeof localeValue) === 'string') && getLocaleUrl() === undefined) {
+    logError('Incorrect or missing locale parameter found. Please review documentation on how to set the locale object in your configuration.');
     setLocaleUrl('https://oil-backend.herokuapp.com/oil/api/userViewLocales/' + getLocaleVariantName());
   }
 

--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -99,8 +99,8 @@ export function isSubscriberSetCookieActive() {
 }
 
 /**
- * The server path from which all chunks and ressources will be loaded.
- * @returns {string, '//oil.axelspringer.com'}
+ * Get the hub iFrame domain with protocol prefix for the current location
+ * @returns {string, null} domain iframe orgin
  */
 export function getHubOrigin() {
   let origin = getConfigValue(OIL_CONFIG.ATTR_HUB_ORIGIN, '//oil.axelspringer.com');
@@ -115,9 +115,8 @@ export function getHubPath() {
 }
 
 /**
- *
- * Get the hub iFrame domain with protocol prefix for the current location
- * @returns {string, null} domain iframe orgin
+ * The server path from which all chunks and ressources will be loaded.
+ * @returns {string, '//oil.axelspringer.com'}
  */
 export function getPublicPath() {
   return getConfigValue(OIL_CONFIG.ATTR_PUBLIC_PATH, undefined);

--- a/src/scripts/core/core_constants.js
+++ b/src/scripts/core/core_constants.js
@@ -8,6 +8,7 @@ export const OIL_CONFIG = {
   ATTR_ACTIVATE_POI: 'poi_activate_poi',
   ATTR_HUB_ORIGIN: 'poi_hub_origin',
   ATTR_HUB_PATH: 'poi_hub_path',
+  ATTR_PUBLIC_PATH: 'publicPath',
   ATTR_HUB_LOCATION: 'poi_hub_location', // complete hub location, gets generated
   ATTR_SUB_SET_COOKIE: 'poi_subscriber_set_cookie',
   ATTR_PREVIEW_MODE: 'preview_mode',

--- a/test/fixtures/config/given.config.with.publicPath.html
+++ b/test/fixtures/config/given.config.with.publicPath.html
@@ -1,0 +1,5 @@
+<script id="oil-configuration" type="application/configuration">
+{
+  "publicPath": "//www"
+}
+</script>

--- a/test/specs/core/core_config.spec.js
+++ b/test/specs/core/core_config.spec.js
@@ -12,14 +12,18 @@ import { getHubPath,
   getAdvancedSettingsPurposesDefault,
   getDefaultToOptin } from '../../../src/scripts/core/core_config';
 import * as CoreConfig from '../../../src/scripts/core/core_config';
-import { loadFixture } from '../../utils.js';
+import { loadFixture, deleteAllCookies } from '../../utils.js';
 import * as CoreLog from '../../../src/scripts/core/core_log';
 
 describe('core_config', () => {
 
+  const DEFAULT_FALLBACK_BACKEND_URL = 'https://oil-backend.herokuapp.com/oil/api/userViewLocales/enEN_01';
+
   beforeEach(() => {
     resetConfiguration();
   });
+
+  afterEach(() => deleteAllCookies());
 
   describe('getConfigValue', () => {
 
@@ -43,8 +47,8 @@ describe('core_config', () => {
 
   describe('parseServerUrls', function() {
 
-    const DEFAULT_FALLBACK_BACKEND_URL  = 'https://oil-backend.herokuapp.com/oil/api/userViewLocales/foo';
-    const EXPECTED_PUBLIC_PATH          = '//www';
+    const DEFAULT_FALLBACK_BACKEND_URL_WITH_LOCALE_STRING  = 'https://oil-backend.herokuapp.com/oil/api/userViewLocales/foo';
+    const EXPECTED_PUBLIC_PATH = '//www';
 
     it('should set __webpack_public_path__', function() {
       loadFixture('config/given.config.with.publicPath.html');
@@ -55,6 +59,12 @@ describe('core_config', () => {
     
     it('Backwards compatibility: creates locale_url property if locale is string and locale_url empty', function(){
       loadFixture('config/given.config.with.locale.string.html');
+      const result = CoreConfig.getLocaleUrl();
+      expect(result).toEqual(DEFAULT_FALLBACK_BACKEND_URL_WITH_LOCALE_STRING);
+    });
+    
+    it('Backwards compatibility: creates locale_url property if locale and locale_url empty', function(){
+      loadFixture('config/empty.config.html');
       const result = CoreConfig.getLocaleUrl();
       expect(result).toEqual(DEFAULT_FALLBACK_BACKEND_URL);
     });
@@ -103,6 +113,8 @@ describe('core_config', () => {
   describe('get config parameters', function() {
 
     const DEFAULT_COOKIE_EXPIRES_IN = 31;
+    const DEFAULT_ADVANCED_SETTINGS_PURPOSES_DEFAULT  = false;
+    const DEFAULT_DEFAULT_TO_OPTIN  = false;
     const DEFAULT_POI_GROUP         = 'default'; 
     const DEFAULT_CUSTOM_PURPOSES   = []; 
     const DEFAULT_HUB_PATH          = '/release/undefined/hub.html'; 
@@ -125,10 +137,10 @@ describe('core_config', () => {
       expect(getHubPath()).toEqual(DEFAULT_HUB_PATH);
       expect(getIabVendorWhitelist()).toBeFalsy();
       expect(getIabVendorBlacklist()).toBeFalsy();
-      expect(getDefaultToOptin()).toEqual(false);
-      expect(getAdvancedSettingsPurposesDefault()).toEqual(false);
+      expect(getDefaultToOptin()).toEqual(DEFAULT_DEFAULT_TO_OPTIN);
+      expect(getAdvancedSettingsPurposesDefault()).toEqual(DEFAULT_ADVANCED_SETTINGS_PURPOSES_DEFAULT);
       expect(getCustomPurposes()).toEqual(DEFAULT_CUSTOM_PURPOSES);
-      expect(getLocaleUrl()).toBeFalsy();
+      expect(getLocaleUrl()).toEqual(DEFAULT_FALLBACK_BACKEND_URL);
       expect(getCookieExpireInDays()).toEqual(DEFAULT_COOKIE_EXPIRES_IN);
       expect(getPoiGroupName()).toEqual(DEFAULT_POI_GROUP);
     });

--- a/test/specs/core/core_config.spec.js
+++ b/test/specs/core/core_config.spec.js
@@ -13,8 +13,9 @@ import { getHubPath,
   getDefaultToOptin } from '../../../src/scripts/core/core_config';
 import * as CoreConfig from '../../../src/scripts/core/core_config';
 import { loadFixture } from '../../utils.js';
+import * as CoreLog from '../../../src/scripts/core/core_log';
 
-describe('core config', () => {
+describe('core_config', () => {
 
   beforeEach(() => {
     resetConfiguration();
@@ -23,8 +24,47 @@ describe('core config', () => {
   describe('getConfigValue', () => {
 
     it('returns default when value not found', function () {
-      let result = CoreConfig.getConfigValue('foo', 'bar');
+      const result = CoreConfig.getConfigValue('foo', 'bar');
       expect(result).toEqual('bar');
+    });
+
+  });
+
+  describe('setConfigValue', function() {
+
+    it('should store config value', function() {
+      CoreConfig.setLocaleUrl('baz');
+      const result = CoreConfig.getLocaleUrl();
+
+      expect(result).toEqual('baz')
+    });
+
+  });
+
+  describe('parseServerUrls', function() {
+
+    const DEFAULT_FALLBACK_BACKEND_URL  = 'https://oil-backend.herokuapp.com/oil/api/userViewLocales/foo';
+    const EXPECTED_PUBLIC_PATH          = '//www';
+
+    it('should set __webpack_public_path__', function() {
+      loadFixture('config/given.config.with.publicPath.html');
+      
+      expect(CoreConfig.getPublicPath()).toEqual(EXPECTED_PUBLIC_PATH);
+      expect(__webpack_public_path__).toEqual(EXPECTED_PUBLIC_PATH);
+    });
+    
+    it('Backwards compatibility: creates locale_url property if locale is string and locale_url empty', function(){
+      loadFixture('config/given.config.with.locale.string.html');
+      const result = CoreConfig.getLocaleUrl();
+      expect(result).toEqual(DEFAULT_FALLBACK_BACKEND_URL);
+    });
+
+    it('should warn about deprecated locale string', function() {
+      loadFixture('config/given.config.with.locale.string.html');
+
+      spyOn(CoreLog, 'logError');
+      const result = CoreConfig.getLocale();
+      expect(CoreLog.logError).toHaveBeenCalled();
     });
 
   });

--- a/test/specs/core/core_config.spec.js
+++ b/test/specs/core/core_config.spec.js
@@ -34,13 +34,13 @@ describe('core_config', () => {
 
   });
 
-  describe('setConfigValue', function() {
+  describe('setLocale', function() {
 
-    it('should store config value', function() {
-      CoreConfig.setLocaleUrl('baz');
-      const result = CoreConfig.getLocaleUrl();
+    it('should store locale value', function() {
+      CoreConfig.setLocale('baz');
+      const result = CoreConfig.getLocale();
 
-      expect(result).toEqual('baz')
+      expect(result).toEqual('baz');
     });
 
   });


### PR DESCRIPTION
- warns when locale in config is a string
- generates locale_url when missing
- adds publicPath configuration constant
- improve test coverage