### PR TITLE
OIL-167: fix soi cookie creation in case that poi cookie exists

### DIFF
--- a/src/scripts/core/core_cookies.js
+++ b/src/scripts/core/core_cookies.js
@@ -1,10 +1,10 @@
 import Cookie from 'js-cookie';
-import {logInfo} from './core_log';
-import {getCookieExpireInDays, getCustomPurposes, getDefaultToOptin, getLanguage, getLanguageFromLocale, getLocaleVariantName} from './core_config';
-import {getLocaleVariantVersion} from './core_utils.js';
-import {OIL_SPEC} from './core_constants';
-import {getLimitedVendorIds, getPurposes, getVendorList, loadVendorList} from './core_vendor_information';
-import {OilVersion} from './core_utils';
+import { logInfo } from './core_log';
+import { getCookieExpireInDays, getCustomPurposes, getDefaultToOptin, getLanguage, getLanguageFromLocale, getLocaleVariantName } from './core_config';
+import { getLocaleVariantVersion } from './core_utils.js';
+import { OIL_SPEC } from './core_constants';
+import { getLimitedVendorIds, getPurposes, getVendorList, loadVendorList } from './core_vendor_information';
+import { OilVersion } from './core_utils';
 
 const {ConsentString} = require('consent-string');
 
@@ -44,19 +44,28 @@ export function getSoiCookie() {
   return cookie;
 }
 
-export function setSoiCookieWithConsentData(consentData, customPurposes) {
+export function setSoiCookieWithPoiCookieData(poiCookieJson) {
   return new Promise((resolve, reject) => {
     loadVendorList().then(() => {
       let cookieConfig = getOilCookieConfig();
+      let consentString;
 
-      consentData.setGlobalVendorList(getVendorList());
+      if (poiCookieJson.consentString) {
+        consentString = poiCookieJson.consentString;
+      } else {
+        let consentData = cookieConfig.defaultCookieContent.consentData;
+        consentData.setPurposesAllowed(poiCookieJson.consentData.allowedPurposeIds);
+        consentData.setVendorsAllowed(poiCookieJson.consentData.allowedVendorIds);
+        consentData.setConsentLanguage(poiCookieJson.consentData.consentLanguage);
+        consentString = consentData.getConsentString();
+      }
       let cookie = {
         opt_in: true,
         version: cookieConfig.defaultCookieContent.version,
         localeVariantName: cookieConfig.defaultCookieContent.localeVariantName,
         localeVariantVersion: cookieConfig.defaultCookieContent.localeVariantVersion,
-        customPurposes: customPurposes,
-        consentString: consentData.getConsentString()
+        customPurposes: poiCookieJson.customPurposes,
+        consentString: consentString
       };
       setDomainCookie(cookieConfig.name, cookie, cookieConfig.expires);
       resolve(cookie);

--- a/src/scripts/core/core_optin.js
+++ b/src/scripts/core/core_optin.js
@@ -1,7 +1,7 @@
-import {verifyPowerOptIn} from './core_poi.js';
-import {logPreviewInfo} from './core_log.js';
-import {isSubscriberSetCookieActive} from './core_config.js';
-import {getSoiCookie, setSoiCookieWithConsentData} from './core_cookies.js';
+import { verifyPowerOptIn } from './core_poi';
+import { logPreviewInfo } from './core_log';
+import { isSubscriberSetCookieActive } from './core_config';
+import { getSoiCookie, setSoiCookieWithPoiCookieData } from './core_cookies';
 
 /**
  * Log Helper function for checkOptIn
@@ -33,9 +33,9 @@ export function checkOptIn() {
       if (powerOptIn.power_opt_in) {
         resultOptIn = powerOptIn.power_opt_in;
         if (isSubscriberSetCookieActive() && !soiOptIn) {
-          setSoiCookieWithConsentData(powerOptIn.consentData).then(() => {
-            resolve(resultOptIn);
-          }).catch(error => reject(error));
+          setSoiCookieWithPoiCookieData(powerOptIn)
+            .then(() => resolve(resultOptIn))
+            .catch(error => reject(error));
         }
       }
       resolve(resultOptIn);

--- a/test/specs/optin.spec.js
+++ b/test/specs/optin.spec.js
@@ -40,22 +40,21 @@ describe('Opt-In', () => {
 
   describe('opt in checker', () => {
     beforeEach(() => {
-      spyOn(CoreCookies, 'setSoiCookieWithConsentData').and.returnValue(new Promise((resolve) => resolve()));
+      spyOn(CoreCookies, 'setSoiCookieWithPoiCookieData').and.returnValue(new Promise((resolve) => resolve()));
     });
 
-    it('should set use the power opt-in for the single opt-in if single opt-in is not defined and power opt-in can be verified', (done) => {
+    it('should use the power opt-in for the single opt-in if single opt-in is not defined and power opt-in can be verified', (done) => {
       let singleOptIn = false;
       let powerOptIn = true;
+      const poiCookieJson = {power_opt_in: powerOptIn, consentData: 'aConsentDataObject'};
       spyOn(CoreCookies, 'getSoiCookie').and.returnValue({opt_in: singleOptIn});
       spyOn(CoreConfig, 'isSubscriberSetCookieActive').and.returnValue(true);
-      spyOn(CorePoi, 'verifyPowerOptIn').and.returnValue(new Promise(resolve => {
-        resolve({power_opt_in: powerOptIn, consentData: 'aConsentDataObject'});
-      }));
+      spyOn(CorePoi, 'verifyPowerOptIn').and.returnValue(new Promise(resolve => resolve(poiCookieJson)));
 
       checkOptIn().then(resultOptIn => {
         expect(resultOptIn).toBe(powerOptIn);
         expect(CorePoi.verifyPowerOptIn).toHaveBeenCalled();
-        expect(CoreCookies.setSoiCookieWithConsentData).toHaveBeenCalledWith('aConsentDataObject');
+        expect(CoreCookies.setSoiCookieWithPoiCookieData).toHaveBeenCalledWith(poiCookieJson);
         done();
       });
     });
@@ -71,7 +70,7 @@ describe('Opt-In', () => {
       checkOptIn().then(resultOptIn => {
         expect(resultOptIn).toBe(singleOptIn);
         expect(CorePoi.verifyPowerOptIn).toHaveBeenCalled();
-        expect(CoreCookies.setSoiCookieWithConsentData).not.toHaveBeenCalled();
+        expect(CoreCookies.setSoiCookieWithPoiCookieData).not.toHaveBeenCalled();
         done();
       });
     });
@@ -88,7 +87,7 @@ describe('Opt-In', () => {
       checkOptIn().then(resultOptIn => {
         expect(resultOptIn).toBe(powerOptIn);
         expect(CorePoi.verifyPowerOptIn).toHaveBeenCalled();
-        expect(CoreCookies.setSoiCookieWithConsentData).not.toHaveBeenCalled();
+        expect(CoreCookies.setSoiCookieWithPoiCookieData).not.toHaveBeenCalled();
         done();
       });
     });
@@ -105,7 +104,7 @@ describe('Opt-In', () => {
       checkOptIn().then(resultOptIn => {
         expect(resultOptIn).toBe(powerOptIn);
         expect(CorePoi.verifyPowerOptIn).toHaveBeenCalled();
-        expect(CoreCookies.setSoiCookieWithConsentData).not.toHaveBeenCalled();
+        expect(CoreCookies.setSoiCookieWithPoiCookieData).not.toHaveBeenCalled();
         done();
       });
     });


### PR DESCRIPTION
Poi cookie json retrieved from message event does not contain a real ConsentString instance as consent data - it is a simple JS 'object' only. Therefore, setGlobalVendorList() function cannot be invoked on it and soi cookie creation fails.
This pull request adds a fix for this problem.