### PR TITLE
no ticket: change quickstart documentation for OIL installation

### DIFF
--- a/docs/src/docs/02-quickstart.adoc
+++ b/docs/src/docs/02-quickstart.adoc
@@ -1,83 +1,63 @@
 == Quickstart
 
-=== Minimal setup
-
-* Add your <<configuring-oil,configuration>> tag, for example:
-
-[source,json]
-----
-<script id="oil-configuration" type="application/configuration">
-  {
-    "publicPath": "//my.server",
-    "locale_url": "//my.server/myLocale.json"
-  }
-</script>
-----
-* Add OIL and the CMP-stub to your website, with a tag manager like <<adding-oil-js-to-your-site-via-tealium-recommended,tealium>> or <<adding-oil-js-to-your-site-via-direct-integration,directly>> as a tag, i.e.:
-
-[source, html, subs="attributes"]
-----
-&lt;script>
-include::../../../dist/oilstub.{version}.min.js[]
-&lt;/script>
-&lt;script type="text/javascript" src="https://oil.axelspringer.com/release/{version_raw}/oil.{version}.min.js">&lt;/script>
-----
-
-
-
-* <<styling-guide,Style>> your layer according to your style guide
-* Create your own <<texts-locale-object,language pack>>
-
-include::02-quickstart/dev-kit.adoc[]
-
 === How to implement OIL on your site
 
 Setting up OIL on your page consists of the following steps:
 
-** Add the oil.js javascript snippet to your page
-** Add a configuration block to your pages DOM
+* <<Install OIL>> on a host of your site.
+* <<Integrate OIL,Add the oil.js javascript snippet>> to your page.
+* <<Configure OIL,Add a configuration>> block to your pages DOM.
+* <<styling-guide,Style>> your layer according to your style guide.
+* Create your own <<texts-locale-object,language pack>>.
 
-OIL creates a standard for the Opt-In but can't automatically stop your site from tracking your users. So to actually make your page respond to opt-ins you also need to do the following.
+OIL creates a standard for the Opt-In but can't automatically stop your site from tracking your users. So to actually make your page respond to opt-ins you also need to do the following:
 
-** Make sure your page doesn't track the user in its default state.
-** Use Tealium for all tracking activities and use the loading rules we provide
-** Listen to OIL events for loading non-Tealium tags, after the user opted in.
+* Make sure your page doesn't track the user in its default state.
+* If possible, use Tealium for all tracking activities and use the loading rules we provide.
+* Listen to OIL events for loading non-Tealium tags, after the user opted in.
+* Use the <<Soft Blocking of DOM Elements,soft-blocking feature>> for tags that OIL provides.
 
-==== Adding oil.js to your site via Tealium (recommended)
+==== Install OIL
 
-Axel Springer Tealium needs to configure your site to inherit the predefined lib-dip-optin library profile. Once this is in place you publish those changes in the following way:
+To add OIL to your site, at first you need an OIL installation. You can download it from https://oil.axelspringer.com/release. The following files must be located on a host of your site:
 
-* Open your Tealium profile and go to "extensions"
-* Find the entry for "AS Opt-in Overlay", you'll be noticed of a change to this extension
-* Publish / deploy your profile to activate the changes to Oil.js
+* `oil.{version}.min.js` - This is the file you will need to reference in your website - see below.
+* `hub.{version}.min.js` - This is the file you will need for the power opt-in feature. See sections <<POI – Power Opt-In>> for details.
+* `hub.html` - This is the file you will need for the power opt-in feature.
+* `poi-lists` - A directory that is needed for the power opt-in feature. It contains JSON files defining POI groups. See sections <<POI – Power Opt-In>> and <<POI-List>> for details.
+* Chunks, beginning with numbers - they will be loaded asynchronously and you don't need to do anything with them.
+** `0.{version}.chunk.js`
+** `X.{version}.chunk.js`
+* `oildevkit.{version}.min.js` - This is the file you will need to use the small OIL SDK. See section <<OIL SDK>> for details.
 
-[caption="Oil.js Tealium Deployment"]
-image::src/images/tealium-user-profile-extension-view.png[Tealium Client Profile]
+The version number is part of `.js` files because updated versions of the scripts will be released using a different filename hence we'll never alter an existing version.
 
-This needs to be repeated for every new version of OIL. The library profile can't push new code to your website without your action.
+==== Integrate OIL
 
-==== Adding oil.js to your site via direct integration
-
-If Tealium can't be used on your site you also can add OIL directly from our CDN.
-
-Example (replace with the latest version):
+To integrate your self-hosted OIL with your website, add the following code:
 [source, html, subs="attributes"]
 ----
 &lt;script>
 include::../../../dist/oilstub.{version}.min.js[]
 &lt;/script>
-&lt;script type="text/javascript" src="https://oil.axelspringer.com/release/{version_raw}/oil.{version}.min.js">&lt;/script>
+&lt;script type="text/javascript" src="https://&lt;your-host&gt;/&lt;path-to-oil&gt;/oil.{version}.min.js">&lt;/script>
 ----
 
-Updated versions of the script will be deployed using a different filename hence we'll never alter an existing version.
+Please make sure you're working with the *latest version* available. Please check https://oil.axelspringer.com/release for further updates. Choose the latest version or the version fitting to this documentation.
 
-Please make sure you're working with the *latest version* available.
+==== Configure OIL
 
-Please check https://oil.axelspringer.com/release for further updates. Choose the latest version or the version fitting to this documentation. Normalley there will be multiple files:
+To ensure that your self-hosted OIL can find all its necessary scripts you must define the `publicPath` parameter in your <<configuring-oil,oil configuration>>.
+It specifies the server path from which all chunks and ressources will be loaded. This is a minimal configuration tag:
 
-* oil.1.0.34-RELEASE.min.js - *This is the file you will need to reference in your website*
-* hub.1.0.34-RELEASE.min.js
-* Chunks, beginning with numbers - they will ne loaded asynchronously and you don't need to do anything with them.
-** 0.1.0.34-RELEASE.chunk.js
-** X.1.0.34-RELEASE.chunk.js
+[source,json,subs="attributes"]
+----
+<script id="oil-configuration" type="application/configuration">
+  {
+    "publicPath": "//&lt;your-host&gt;/&lt;path-to-oil&gt;",
+    "locale_url": "//&lt;your-host&gt;/&lt;path-to-locale&gt;myLocale.json"
+  }
+</script>
+----
 
+include::02-quickstart/dev-kit.adoc[]

--- a/docs/src/docs/02-quickstart/dev-kit.adoc
+++ b/docs/src/docs/02-quickstart/dev-kit.adoc
@@ -7,7 +7,7 @@ image::src/images/dev-kit-02.png[]
 
 Add this to your favorites and open the link on the website you want it to be included:
 
-[source,javascript]
+[source,javascript, subs="attributes"]
 ----
-include::dev-kit.js[]
+javascript:(function () {let d = document, s = d.createElement('script');s.id = 'oil-dev-kit-js';s.src = '//&lt;oil-host&gt;/&lt;path-to-oil&gt;/oildevkit.{version}.min.js';(d.head || d.body).appendChild(s)}());
 ----

--- a/docs/src/docs/02-quickstart/dev-kit.js
+++ b/docs/src/docs/02-quickstart/dev-kit.js
@@ -1,1 +1,0 @@
-javascript:(function () {let d = document, s = d.createElement('script');s.id = 'oil-dev-kit-js';s.src = '//oil.axelspringer.com/latest/oildevkit.min.js';(d.head || d.body).appendChild(s)}());


### PR DESCRIPTION
* remove references to Axel Springer CDN
* remove incomplete Tealium documentation (specific for Axel Springer) 