### PR TITLE
fix: Hide iframe for screen readers and remove whitespace

### DIFF
--- a/src/scripts/core/core_poi.js
+++ b/src/scripts/core/core_poi.js
@@ -17,12 +17,15 @@ export function addFrame(iframeUrl) {
     logInfo('Creating iframe...');
     iframe = document.createElement('iframe');
     iframe.setAttribute('id', 'oil-frame');
+    iframe.setAttribute('title', 'oil-frame');
+    iframe.setAttribute('aria-hidden', 'true');
     iframe.setAttribute('src', iframeUrl);
     iframe.setAttribute('sandbox', 'allow-same-origin allow-scripts allow-forms allow-top-navigation');
     iframe.style.width = '0';
     iframe.style.height = '0';
     iframe.style.border = '0';
     iframe.style.border = 'none';
+    iframe.style.display = 'block';
     document.body.appendChild(iframe);
   } else {
     logInfo('Found iframe');

--- a/test/e2e/optout_confirm_deactivated_test.js
+++ b/test/e2e/optout_confirm_deactivated_test.js
@@ -25,7 +25,7 @@ module.exports = {
       .pause(100)
       .waitForElementNotPresent(OIL_OPTOUT_CONFIRM, 2500)
       .end()
-  },
+  }
 
 
 };


### PR DESCRIPTION
This PR does two things:
1. Adds a [title](https://dequeuniversity.com/rules/axe/2.2/frame-title?application=lighthouse) and [aria-hidden](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden) attributes to the POI iframe. 
2. Removes whitespace from iframe by using `display: block`. This issue seems to not be there on the demo pages, but we experience this on our sites. Screenshots below.

In these screenshots I moved the iframe to the top of the page to illustrate better.
Without `display: block`:
![image](https://user-images.githubusercontent.com/467326/43577455-2b9b40e0-964c-11e8-9f30-9bc2331140e2.png)

With `display: block`:
![image](https://user-images.githubusercontent.com/467326/43577489-416645be-964c-11e8-8c5d-1178a1cd8a16.png)

Note: I did not run tests because `ChromeHeadless` failed.