### PR TITLE
feat: Allow node 9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": ">= 8.8 <9",
+    "node": ">= 8.8",
     "npm": ">= 6.0"
   },
   "files": [


### PR DESCRIPTION
Currently your package.json locks us into using Node 8, this change will allow us to use any version above node 8.

We have been using OIL 1.2.1 with Node 10 without any issues so far.