### PR TITLE
fix: Only request vendorlist once

### DIFF
--- a/src/scripts/core/core_vendor_information.js
+++ b/src/scripts/core/core_vendor_information.js
@@ -17,11 +17,11 @@ export function loadVendorList() {
     if (cachedVendorList) {
       resolve(cachedVendorList);
     } else if (pendingVendorlistPromise) {
-      return pendingVendorlistPromise;
+      resolve(pendingVendorlistPromise);
     } else {
       let iabVendorListUrl = getIabVendorListUrl();
       pendingVendorlistPromise = fetchJsonData(iabVendorListUrl)
-        .then(response => {
+      pendingVendorlistPromise.then(response => {
           cachedVendorList = response;
           pendingVendorlistPromise = null;
           sortVendors(cachedVendorList);

--- a/src/scripts/core/core_vendor_information.js
+++ b/src/scripts/core/core_vendor_information.js
@@ -15,11 +15,9 @@ export let pendingVendorlistPromise = null;
 export function loadVendorList() {
   return new Promise(function (resolve) {
     if (cachedVendorList) {
-      // if we have cached vendorlist, return that
       resolve(cachedVendorList);
     } else if (pendingVendorlistPromise) {
-      // if there already is a request pending, lets return the promise
-      return pendingVendorlistPromise
+      return pendingVendorlistPromise;
     } else {
       let iabVendorListUrl = getIabVendorListUrl();
       pendingVendorlistPromise = fetchJsonData(iabVendorListUrl)

--- a/src/scripts/core/core_vendor_information.js
+++ b/src/scripts/core/core_vendor_information.js
@@ -10,12 +10,35 @@ export const DEFAULT_VENDOR_LIST = {
 };
 
 export let cachedVendorList;
+export let startedVendorlistRequest = false;
 
 export function loadVendorList() {
   return new Promise(function (resolve) {
     if (cachedVendorList) {
+      // if we have cached vendorlist, return that
       resolve(cachedVendorList);
+    } else if (startedVendorlistRequest) {
+      // if a request for the vendorlist has been started, let's wait for it
+      return new Promise(function (resolve) {
+        function getCachedVendorList(timeout) {
+          if (cachedVendorList) {
+            resolve(cachedVendorList)
+          } else {
+            // if this takes too long we need to return the default
+            if (timeout > 10000) {
+              logError('OIL getVendorList started request but did not resolve in 10 seconds. Falling back to default vendor list!');
+              resolve(getVendorList());
+            }
+            // check for cached vendor list in 4ms, 8ms, 16ms etc until we get it or it takes too long
+            setTimeout(getCachedVendorList.bind(null, timeout * 2), timeout);
+          }
+        }
+        getCachedVendorList(2)
+      })
+
     } else {
+      // if we have no cached version and no request has been started, do request and set flag for started request
+      startedVendorlistRequest = true
       let iabVendorListUrl = getIabVendorListUrl();
       fetchJsonData(iabVendorListUrl)
         .then(response => {
@@ -67,6 +90,7 @@ export function getVendorList() {
 
 export function clearVendorListCache() {
   cachedVendorList = undefined;
+  startedVendorlistRequest = false;
 }
 
 export function getVendorsToDisplay() {

--- a/test/specs/core/core_vendor_information.spec.js
+++ b/test/specs/core/core_vendor_information.spec.js
@@ -11,7 +11,9 @@ import {
   getVendors,
   getLimitedVendors,
   getVendorsToDisplay,
-  loadVendorList
+  loadVendorList,
+  cachedVendorList,
+  pendingVendorlistPromise
 } from '../../../src/scripts/core/core_vendor_information';
 import VENDOR_LIST from '../../fixtures/vendorlist/simple_vendor_list.json';
 import { resetOil } from '../../test-utils/utils_reset';
@@ -56,11 +58,26 @@ describe('core_vendor_information', () => {
       let fetchSpy = spyOn(CoreUtils, 'fetchJsonData').and.returnValue(new Promise((resolve) => resolve(VENDOR_LIST)));
       spyOn(CoreConfig, 'getIabVendorListUrl').and.returnValue("https://iab.vendor.list.url");
 
-      loadVendorList().then(() => {});
-      loadVendorList().then(() => {});
-      loadVendorList().then(() => {});
-      loadVendorList().then(() => {});
+      expect(pendingVendorlistPromise).toBeNull();
+      expect(cachedVendorList).toBeUndefined();
+      loadVendorList().then((retrievedVendorList) => {
+        expect(retrievedVendorList.vendorListVersion).toEqual(VENDOR_LIST.vendorListVersion);
+        expect(retrievedVendorList).toEqual(VENDOR_LIST);
+        expect(cachedVendorList).toBeDefined();
+      });
+      expect(cachedVendorList).toBeUndefined();
+      expect(pendingVendorlistPromise).toBeDefined();
+      loadVendorList().then((retrievedVendorList) => {
+        expect(retrievedVendorList.vendorListVersion).toEqual(VENDOR_LIST.vendorListVersion);
+        expect(retrievedVendorList).toEqual(VENDOR_LIST);
+      });
+      expect(cachedVendorList).toBeUndefined();
+      loadVendorList().then((retrievedVendorList) => {
+        expect(retrievedVendorList.vendorListVersion).toEqual(VENDOR_LIST.vendorListVersion);
+        expect(retrievedVendorList).toEqual(VENDOR_LIST);
+      });
       expect(fetchSpy.calls.count()).toBe(1);
+
       done();
     });
 

--- a/test/specs/core/core_vendor_information.spec.js
+++ b/test/specs/core/core_vendor_information.spec.js
@@ -75,10 +75,10 @@ describe('core_vendor_information', () => {
       loadVendorList().then((retrievedVendorList) => {
         expect(retrievedVendorList.vendorListVersion).toEqual(VENDOR_LIST.vendorListVersion);
         expect(retrievedVendorList).toEqual(VENDOR_LIST);
+        done();
       });
       expect(fetchSpy.calls.count()).toBe(1);
 
-      done();
     });
 
     it('should use default vendor list if vendor list fetching fails', (done) => {

--- a/test/specs/core/core_vendor_information.spec.js
+++ b/test/specs/core/core_vendor_information.spec.js
@@ -52,6 +52,19 @@ describe('core_vendor_information', () => {
       });
     });
 
+    it('should wait for cached vendor list if request is already started', (done) => {
+      let fetchSpy = spyOn(CoreUtils, 'fetchJsonData').and.returnValue(new Promise((resolve) => resolve(VENDOR_LIST)));
+      spyOn(CoreConfig, 'getIabVendorListUrl').and.returnValue("https://iab.vendor.list.url");
+
+      loadVendorList().then(() => {});
+      loadVendorList().then(() => {});
+      loadVendorList().then(() => {});
+      loadVendorList().then(() => {});
+      console.log("Fetchspy.calls.count(): ", fetchSpy.calls.count());
+      expect(fetchSpy.calls.count()).toBe(1);
+      done();
+    });
+
     it('should use default vendor list if vendor list fetching fails', (done) => {
       spyOn(CoreUtils, 'fetchJsonData').and.returnValue(new Promise((resolve, reject) => reject(new Error("something went wrong"))));
       spyOn(CoreConfig, 'getIabVendorListUrl').and.returnValue("https://iab.vendor.list.url");
@@ -273,7 +286,7 @@ describe('core_vendor_information', () => {
   });
 
   describe('getLimitedVendors', function() {
-    
+
     it('returns regular vendors when no whitelist or blacklist exists', function() {
       spyOn(CoreConfig, 'getShowLimitedVendors').and.returnValue(true);
       expect(getLimitedVendors().length).toEqual(DEFAULT_VENDOR_LIST.maxVendorId);
@@ -294,7 +307,7 @@ describe('core_vendor_information', () => {
   });
 
   describe('getVendorsToDisplay', function() {
-    
+
     it('should return full vendor list when configuration parameter show_limited_vendors_only is false', function() {
       spyOn(CoreConfig, 'getShowLimitedVendors').and.returnValue(false);
       let result = getVendorsToDisplay();

--- a/test/specs/core/core_vendor_information.spec.js
+++ b/test/specs/core/core_vendor_information.spec.js
@@ -60,7 +60,6 @@ describe('core_vendor_information', () => {
       loadVendorList().then(() => {});
       loadVendorList().then(() => {});
       loadVendorList().then(() => {});
-      console.log("Fetchspy.calls.count(): ", fetchSpy.calls.count());
       expect(fetchSpy.calls.count()).toBe(1);
       done();
     });


### PR DESCRIPTION
Fixes #206 

This PR sets a flag whenever you do a request for the vendorlist, so if there is several calls to `loadVendorList()` before the request is resolved and cache is saved, we wait for the first request to resolve in the other calls.