### PR TITLE
OIL-297 FIXED Labels with Prefix label_cpc_purpose no loaded correctly

### DIFF
--- a/src/scripts/userview/locale/userview_oil.js
+++ b/src/scripts/userview/locale/userview_oil.js
@@ -12,50 +12,82 @@ export {
   oilWrapper
 } from '../userview_modal';
 
+/**
+ *
+ * Loads the locale information and fills missing texts
+ *
+ * @param callback function which gets called after locale is loaded
+ * @returns {*}
+ */
 export function locale(callback) {
-  let localeObject = getLocale();
-  const missingLabels = (localeObject && localeObject.texts) ? findMissingLabels(localeObject.texts) : [];
+  let localeObjectFromConfiguration = getLocale();
 
-  if (localeObject && localeObject.texts && missingLabels.length === 0) {
+  if (hasMissingLabels(localeObjectFromConfiguration)) {
     return callback(this);
   } else {
     const localeUrl = getLocaleUrl();
 
     if (localeUrl) {
       fetchJsonData(localeUrl)
-      .then(response => {
-        fillAndSetLocaleObject(response, localeObject, missingLabels);
-        return callback(this);
-      })
-      .catch(error => {
-        logError(`OIL backend returned error: ${error}. Falling back to default locale '${DEFAULT_LOCALE.localeId}', version ${DEFAULT_LOCALE.version}!`);
-        fillAndSetLocaleObject(DEFAULT_LOCALE, localeObject, missingLabels);
-        return callback(this);
-      });
+        .then(response => {
+          fillAndSetLocaleObject(response, localeObjectFromConfiguration);
+          return callback(this);
+        })
+        .catch(error => {
+          logError(`OIL backend returned error: ${error}. Falling back to default locale '${DEFAULT_LOCALE.localeId}', version ${DEFAULT_LOCALE.version}!`);
+          fillAndSetLocaleObject(DEFAULT_LOCALE, localeObjectFromConfiguration);
+
+          return callback(this);
+        });
     } else {
-      fillAndSetLocaleObject(DEFAULT_LOCALE, localeObject, missingLabels);
+      // HINT: For no localeUrl we enrich the configured locale with our default locale
+      fillAndSetLocaleObject(DEFAULT_LOCALE, localeObjectFromConfiguration);
       return callback(this);
     }
   }
 }
 
-function fillAndSetLocaleObject(sourceObject, targetObject, missingLabels) {
+function hasMissingLabels(localeObjectFromConfiguration) {
+  const missingLabels = (localeObjectFromConfiguration && localeObjectFromConfiguration.texts) ? findMissingLabels(localeObjectFromConfiguration.texts) : [];
+  return localeObjectFromConfiguration && localeObjectFromConfiguration.texts && missingLabels.length === 0;
+}
+
+/**
+ * Gets a source and a target and adds all missing labels from the source to the target
+ *
+ * @param sourceObject default object
+ * @param targetObject object with missing labels
+ */
+function fillAndSetLocaleObject(sourceObject, targetObject) {
   if (!targetObject || !targetObject.texts) {
+    console.error('ªfillAndSetLocaleObject: use SOURCEOBJECT, target was', targetObject);
     setLocale(sourceObject);
     return;
   }
 
-  missingLabels.forEach((label) => {
-    if(!sourceObject.texts[label]){
-      logWarn(`${label} missing from locale config.`);
-    } else {
-      targetObject.texts[label] = sourceObject.texts[label];
+  for (let key in sourceObject.texts) {
+    if (!targetObject.texts[key]) {
+      targetObject.texts[key] = sourceObject.texts[key];
     }
-  });
+  }
+
+  // Check for missing keys against default configuration
+  for (let key in DEFAULT_LOCALE.texts) {
+    if (!targetObject.texts[key]) {
+      logWarn(`${key} missing from locale config.`);
+    }
+  }
 
   setLocale(targetObject);
 }
 
+/**
+ * Determines which label-keys are mandatory.
+ * Currently all labels starting with "label_cpc_purpose" are optional.
+ *
+ * @param locale
+ * @returns {any[]} An array with all keys of missing labels
+ */
 function findMissingLabels(locale) {
   const requiredLabels = Object.values(OIL_LABELS).filter(key => !key.startsWith(OPTIONAL_LABEL_PREFIX));
   return requiredLabels.filter(key => !locale[key]);

--- a/test/specs/userview/locale/userview_oil.spec.js
+++ b/test/specs/userview/locale/userview_oil.spec.js
@@ -1,10 +1,10 @@
-import * as UserViewOil from '../../../src/scripts/userview/locale/userview_oil';
-import * as CoreUtils from '../../../src/scripts/core/core_utils';
-import * as CoreConfig from '../../../src/scripts/core/core_config';
-import * as CoreLog from '../../../src/scripts/core/core_log';
-import { OIL_LABELS } from '../../../src/scripts/userview/userview_constants';
-import DEFAULT_LOCALE from '../../../src/scripts/userview/locale/userview_default_locale';
-import { resetOil } from '../../test-utils/utils_reset';
+import * as UserViewOil from '../../../../src/scripts/userview/locale/userview_oil';
+import * as CoreUtils from '../../../../src/scripts/core/core_utils';
+import * as CoreConfig from '../../../../src/scripts/core/core_config';
+import * as CoreLog from '../../../../src/scripts/core/core_log';
+import { OIL_LABELS } from '../../../../src/scripts/userview/userview_constants';
+import DEFAULT_LOCALE from '../../../../src/scripts/userview/locale/userview_default_locale';
+import { resetOil } from '../../../test-utils/utils_reset';
 
 describe('the locale fetcher for user view modal', () => {
 
@@ -80,10 +80,12 @@ describe('the locale fetcher for user view modal', () => {
   });
 
   it('should update existing but incomplete locale from configuration by locale loaded from backend', (done) => {
-    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_START, OIL_LABELS.ATTR_LABEL_BUTTON_BACK]);
-    const expectedLocale = setValuesToLocale(configuredLocale, {
+    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_START, OIL_LABELS.ATTR_LABEL_BUTTON_BACK, OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]);
+    const expectedLocale = addValuesToLocaleCopy(configuredLocale, {
       [OIL_LABELS.ATTR_LABEL_INTRO_START]: BACKEND_LOCALE.texts[OIL_LABELS.ATTR_LABEL_INTRO_START],
-      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: BACKEND_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK]
+      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: BACKEND_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]: BACKEND_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC],
+
     });
     givenThatConfigurationContainsLocale(configuredLocale);
     givenThatBackendProvidesLocale(BACKEND_LOCALE);
@@ -97,10 +99,13 @@ describe('the locale fetcher for user view modal', () => {
   });
 
   it('should update existing but incomplete locale from configuration by locale loaded from backend with warning about missing labels', (done) => {
-    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_START, OIL_LABELS.ATTR_LABEL_BUTTON_BACK]);
+    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [
+      OIL_LABELS.ATTR_LABEL_INTRO_START,
+      OIL_LABELS.ATTR_LABEL_BUTTON_BACK
+    ]);
     const backendLocale = removeKeysFromLocale(BACKEND_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_START]);
-    const expectedLocale = setValuesToLocale(configuredLocale, {
-      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: BACKEND_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK]
+    const expectedLocale = addValuesToLocaleCopy(configuredLocale, {
+      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: BACKEND_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK],
     });
     givenThatConfigurationContainsLocale(configuredLocale);
     givenThatBackendProvidesLocale(backendLocale);
@@ -116,10 +121,15 @@ describe('the locale fetcher for user view modal', () => {
   });
 
   it('should update existing but incomplete locale from configuration by default locale in case of an error while retrieving locale from backend', (done) => {
-    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_HEADING, OIL_LABELS.ATTR_LABEL_BUTTON_BACK]);
-    const expectedLocale = setValuesToLocale(configuredLocale, {
+    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_HEADING, OIL_LABELS.ATTR_LABEL_BUTTON_BACK, OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]);
+    const expectedLocale = addValuesToLocaleCopy(configuredLocale, {
       [OIL_LABELS.ATTR_LABEL_INTRO_HEADING]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_INTRO_HEADING],
-      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK]
+      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_HEADING]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_HEADING],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_TEXT]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_TEXT],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_PROCEED]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_PROCEED],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_CANCEL]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_CANCEL]
     });
     givenThatConfigurationContainsLocale(configuredLocale);
     givenThatLocaleRetrievalFromBackendFails();
@@ -133,10 +143,17 @@ describe('the locale fetcher for user view modal', () => {
   });
 
   it('should update existing but incomplete locale from configuration by default locale in case of non-existing locale url', (done) => {
-    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_HEADING, OIL_LABELS.ATTR_LABEL_BUTTON_BACK]);
-    const expectedLocale = setValuesToLocale(configuredLocale, {
+    console.info('##### RUNNING TEST #####');
+
+    const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_HEADING, OIL_LABELS.ATTR_LABEL_BUTTON_BACK, OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]);
+    const expectedLocale = addValuesToLocaleCopy(configuredLocale, {
       [OIL_LABELS.ATTR_LABEL_INTRO_HEADING]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_INTRO_HEADING],
-      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK]
+      [OIL_LABELS.ATTR_LABEL_BUTTON_BACK]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_BUTTON_BACK],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_HEADING]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_HEADING],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_TEXT]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_TEXT],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_PROCEED]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_PROCEED],
+      [OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_CANCEL]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_OPTOUT_CANCEL]
     });
     givenThatConfigurationContainsLocale(configuredLocale);
     givenThatLocaleRetrievalIsDeactivated();
@@ -144,6 +161,7 @@ describe('the locale fetcher for user view modal', () => {
     UserViewOil.locale(userViewOil => {
       expect(userViewOil).toBeDefined();
       expect(CoreUtils.fetchJsonData).not.toHaveBeenCalled();
+      expect(CoreConfig.setLocale).toHaveBeenCalledTimes(1);
       expect(CoreConfig.setLocale).toHaveBeenCalledWith(expectedLocale);
       done();
     });
@@ -206,7 +224,7 @@ describe('the locale fetcher for user view modal', () => {
     };
   }
 
-  function setValuesToLocale(locale, valuesToAdd) {
+  function addValuesToLocaleCopy(locale, valuesToAdd) {
     let result = {
       'localeId': locale.localeId,
       'version': locale.version,


### PR DESCRIPTION
Current procedure:

* OIL-Config with "texts" is loaded
* Missing labels are determined
    * And missing labels are only mandatory, i.e. all labels that do not start with label_cpc_purpose. Here is a filter in it
* If localeUrl is defined, the missing information will be loaded from it.

This means that the current implementation does not overwrite it.

Solution: Currently only missing labels are overwritten. This does not make sense. You can simply take anything that is not defined from the localeUrl.
