### PR TITLE
fix: invalid json in quickstart guide's configurations example

### DIFF
--- a/docs/src/docs/02-quickstart.adoc
+++ b/docs/src/docs/02-quickstart.adoc
@@ -115,7 +115,7 @@ Note that you will have to add your own locale to the configuration block. See <
 &lt;script id="oil-configuration" type="application/configuration"&gt;
   {
     "publicPath": "https://unpkg.com/@ideasio/oil.js/release/current/",
-    "locale": { localeId: "myLocale", version: "1", texts: {"label_intro_heading":"I am a stub" }}
+    "locale": { "localeId": "myLocale", "version": "1", "texts": {"label_intro_heading":"I am a stub" }}
   }
 &lt;/script&gt;
 ----


### PR DESCRIPTION
The example code in documentation for "Quickstart" > "Configure OIL" > "Delivery through unpkg.com" contained invalid json.

As the configuration json isn't valid json, oil silently skips the configuration, and reverts to default values.

As the example code is in the quickstart guide, this can lead to some confusion for people trying out oil for the first time.