### PR TITLE
fix advanced_settings_purposes_default with custom purposes (#241)

### DIFF
--- a/src/scripts/userview/userview_modal.js
+++ b/src/scripts/userview/userview_modal.js
@@ -34,7 +34,8 @@ import {
   gdprApplies,
   getAdvancedSettingsPurposesDefault,
   isPoiActive,
-  isSubscriberSetCookieActive
+  isSubscriberSetCookieActive,
+  getCustomPurposeIds
 } from '../core/core_config';
 import { applyPrivacySettings, getPrivacySettings, getSoiConsentData } from './userview_privacy';
 import { activateOptoutConfirm } from './userview_optout_confirm.js';
@@ -105,7 +106,7 @@ export function oilShowPreferenceCenter() {
           if (consentData) {
             currentPrivacySettings = consentData.getPurposesAllowed();
           } else {
-            currentPrivacySettings = getAdvancedSettingsPurposesDefault() ? getPurposeIds() : [];
+            currentPrivacySettings = getAdvancedSettingsPurposesDefault() ? [...getPurposeIds(), ...getCustomPurposeIds()] : [];
           }
           applyPrivacySettings(currentPrivacySettings);
         })

--- a/src/scripts/userview/userview_privacy.js
+++ b/src/scripts/userview/userview_privacy.js
@@ -2,7 +2,6 @@ import {getSoiCookie} from '../core/core_cookies.js';
 import {PRIVACY_FULL_TRACKING} from '../core/core_constants';
 import {logInfo} from '../core/core_log';
 import {forEach} from './userview_modal';
-import {getPurposes} from '../core/core_vendor_information';
 
 export function getSoiConsentData() {
   let soiCookie = getSoiCookie();
@@ -33,19 +32,18 @@ export function getPrivacySettings() {
 export function applyPrivacySettings(allowedPurposes) {
   logInfo('Apply privacy settings from cookie', allowedPurposes);
 
-  for (let i = 1; i <= getPurposes().length; i++) {
-    document.querySelector(`#as-js-purpose-slider-${i}`).checked = (allowedPurposes.indexOf(i) !== -1);
-  }
-
   if (allowedPurposes === 1) {
     forEach(document.querySelectorAll('.as-js-purpose-slider'), (domNode) => {
       domNode && (domNode.checked = true);
     });
-  }
-
-  if (allowedPurposes === 0) {
+  } else if (allowedPurposes === 0) {
     forEach(document.querySelectorAll('.as-js-purpose-slider'), (domNode) => {
       domNode && (domNode.checked = false);
     });
+  } else if (allowedPurposes) {
+    allowedPurposes.map(function(allowedPurpose) {
+      document.querySelector(`#as-js-purpose-slider-${allowedPurpose}`).checked = (allowedPurpose !== -1);
+    });
   }
+
 }


### PR DESCRIPTION
Hi,

This pr should fix #241. It makes config option `advanced_settings_purposes_default=true` to also work with custom purposes.

This appeared to be a rather straightforward fix, and as far as I looked, it didn't affect anything else than the exact functionality with the `advanced_settings_purposes_default` option, when the option is enabled.

Tests were green after the change.