### PR TITLE
Oil 320/e2e

### DIFF
--- a/etc/appConfig.js
+++ b/etc/appConfig.js
@@ -262,6 +262,12 @@ module.exports = {
     chunksSortMode: 'dependency',
     inject: 'head'
   }, {
+    filename: 'demos/custom-vendors-notification.html',
+    template: path.resolve(sourcePath, 'demos', 'custom-vendors-notification.html'),
+    chunks: ['oilstub', 'oil'],
+    chunksSortMode: 'dependency',
+    inject: 'head'
+  }, {
     filename: 'demos/vendor-integration-iframe.html',
     chunks: [],
     template: path.resolve(sourcePath, 'demos', 'vendor-integration-iframe.html')

--- a/package-lock.json
+++ b/package-lock.json
@@ -6913,8 +6913,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6935,14 +6934,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6957,20 +6954,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7087,8 +7081,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7100,7 +7093,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7115,7 +7107,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7123,14 +7114,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7149,7 +7138,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7230,8 +7218,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7243,7 +7230,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7329,8 +7315,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7366,7 +7351,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7386,7 +7370,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7430,14 +7413,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10513,7 +10494,7 @@
       "dev": true,
       "requires": {
         "bower": "^1.3.9",
-        "bower-installer": "git://github.com/bessdsv/bower-installer.git#temp"
+        "bower-installer": "git://github.com/bessdsv/bower-installer.git#7f9cece1e6fada50f44dc0851e1d85815cd1b4a7"
       }
     },
     "karma-junit-reporter": {
@@ -15305,9 +15286,9 @@
       "dev": true
     },
     "selenium-download": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/selenium-download/-/selenium-download-2.0.13.tgz",
-      "integrity": "sha512-ZAH4NK9kx2/YO0IyNTapsN8Zfgfa6UkODeEoTNaxLFdidENe+Z8DMuIgtsdQof462PNTcbprCM7wgL3t1zDOMQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/selenium-download/-/selenium-download-2.0.14.tgz",
+      "integrity": "sha512-ygWSA+SZbBiI+ArejK0HZ7Q8HvtSKWFibSjePra0/4okm5lgFFKn8ene36H5P6CKffILqwFRhfNoM19Jp3x9uQ==",
       "dev": true,
       "requires": {
         "adm-zip": "~0.4.4",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "remap-istanbul": "0.11.0",
     "rimraf": "2.6.2",
     "sass-loader": "7.0.1",
-    "selenium-download": "2.0.13",
+    "selenium-download": "2.0.14",
     "serve-index": "1.9.1",
     "serve-static": "1.13.2",
     "source-map-loader": "0.2.3",

--- a/src/demos/custom-vendors-notification.html
+++ b/src/demos/custom-vendors-notification.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>Test Page</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <!-- tag::oil-config[] -->
+  <script id="oil-configuration" type="application/configuration">
+      {
+        "config_version": 1,
+        "advanced_settings": false,
+        "timeout": -1,
+        "publicPath": "/",
+        "customVendorListUrl": "https://www.oiljs.org/customvendors-example.json"
+      }
+
+
+  </script>
+  <!-- end::oil-config[] -->
+  <style>
+    body {
+      font-family: 'Nunito', sans-serif;
+      font-size: 60px;
+      color: #f7f7f7;
+      height: 100%;
+      background: linear-gradient(20deg, #3a871a 0%, #a5ba10 50%, #cfcd26 100%);
+      padding: 0;
+      margin: 0;
+    }
+
+    .demoname {
+      padding: 24px;
+    }
+  </style>
+</head>
+
+<body>
+<div class="demoname">Custom Vendor Notification</div>
+<div id="customVendor1DependentElement"></div>
+<div id="customVendor2DependentElement"></div>
+<script type="text/javascript">
+  window.setInterval(function() {
+    // we use global variables here to test whether custom vendor's JS snippets are executed in the right scope - the global scope
+    if (hasCustomVendor1Consent) {
+      document.getElementById('customVendor1DependentElement').innerText = 'Custom Vendor 1 was opted in';
+    } else {
+      document.getElementById('customVendor1DependentElement').innerText = 'Custom Vendor 1 was opted out';
+    }
+    if (hasCustomVendor2Consent) {
+      document.getElementById('customVendor2DependentElement').innerText = 'Custom Vendor 2 was opted in';
+    } else {
+      document.getElementById('customVendor2DependentElement').innerText = 'Custom Vendor 2 was opted out';
+    }
+  }, 200);
+</script>
+</body>
+</html>

--- a/src/scripts/core/core_custom_vendors.js
+++ b/src/scripts/core/core_custom_vendors.js
@@ -30,7 +30,12 @@ function sendConsentInformationToCustomVendor(customVendor, consentData) {
 function executeCustomVendorScript(scriptType, script, customVendor) {
   if (script) {
     try {
-      eval(script)
+      // Note: We assign eval function to a variable and invoke it this way indirectly. This ensures that's the scope
+      // for executed JavaScript function is global and not the scope of this function! We need this to enable the
+      // executed script to set (global) variables that are reachable for other code snippets (i.e. for webtrekk) of
+      // the website the opt-in layer is integrated in.
+      let evalFunction = eval;
+      evalFunction(script)
     } catch (error) {
       logError('Error occurred while executing ' + scriptType + ' script for custom vendor ' + customVendor.id + ' (' + customVendor.name + ')! Error was: ', error);
     }

--- a/src/scripts/core/core_oil.js
+++ b/src/scripts/core/core_oil.js
@@ -4,10 +4,11 @@ import { logError, logInfo, logPreviewInfo } from './core_log';
 import { checkOptIn } from './core_optin';
 import { getSoiCookie, isBrowserCookieEnabled, isPreviewCookieSet, removePreviewCookie, removeVerboseCookie, setPreviewCookie, setVerboseCookie } from './core_cookies';
 import { doSetTealiumVariables } from './core_tealium_loading_rules';
-import { getLocale, isPreviewMode, resetConfiguration, setGdprApplies} from './core_config';
+import { getLocale, isPreviewMode, resetConfiguration, setGdprApplies } from './core_config';
 import { EVENT_NAME_HAS_OPTED_IN, EVENT_NAME_NO_COOKIES_ALLOWED } from './core_constants';
 import { executeCommandCollection } from './core_command_collection';
 import { manageDomElementActivation } from './core_tag_management';
+import { sendConsentInformationToCustomVendors } from './core_custom_vendors';
 
 /**
  * Initialize Oil on Host Site
@@ -57,6 +58,7 @@ export function initOilLayer() {
         sendEventToHostSite(EVENT_NAME_HAS_OPTED_IN);
         executeCommandCollection();
         attachCommandCollectionFunctionToWindowObject();
+        sendConsentInformationToCustomVendors().then(() => logInfo('Consent information sending to custom vendors after OIL start with found opt-in finished!'));
       } else {
         /**
          * Any other case, when the user didn't decide before and oil needs to be shown:
@@ -69,6 +71,7 @@ export function initOilLayer() {
           .catch((e) => {
             logError('Locale could not be loaded.', e);
           });
+        sendConsentInformationToCustomVendors().then(() => logInfo('Consent information sending to custom vendors after OIL start without found opt-in finished!'));
       }
     });
   }

--- a/src/scripts/core/core_optout.js
+++ b/src/scripts/core/core_optout.js
@@ -4,18 +4,16 @@ import { removeSubscriberCookies } from './core_cookies.js';
 import { sendEventToHostSite } from './core_utils';
 import { EVENT_NAME_OPT_OUT } from './core_constants';
 import { manageDomElementActivation } from './core_tag_management';
+import { executeCommandCollection } from './core_command_collection';
+import { sendConsentInformationToCustomVendors } from './core_custom_vendors';
 
-/**
- * Opt-Out Handler
- *
- * @return none
- */
-// FIXME write test
 export function handleOptOut() {
   logInfo('OptOut Received.');
   // Update Oil cookie
   removeSubscriberCookies();
   // delete POI too if exists
   deActivatePowerOptIn().then(() => sendEventToHostSite(EVENT_NAME_OPT_OUT));
+  executeCommandCollection();
+  sendConsentInformationToCustomVendors().then(() => logInfo('Consent information sending to custom vendors after opt-out is done!'));
   manageDomElementActivation();
 }

--- a/src/scripts/userview/userview_modal.js
+++ b/src/scripts/userview/userview_modal.js
@@ -30,6 +30,7 @@ import { applyPrivacySettings, getPrivacySettings, getSoiConsentData } from './u
 import { activateOptoutConfirm } from './userview_optout_confirm';
 import { getPurposeIds, loadVendorListAndCustomVendorList } from '../core/core_vendor_lists';
 import { manageDomElementActivation } from '../core/core_tag_management';
+import { sendConsentInformationToCustomVendors } from '../core/core_custom_vendors';
 
 // Initialize our Oil wrapper and save it ...
 
@@ -122,6 +123,7 @@ function onOptInComplete() {
   if (commandCollectionExecutor) {
     commandCollectionExecutor();
   }
+  sendConsentInformationToCustomVendors().then(() => logInfo('Consent information sending to custom vendors after user\'s opt-in finished!'));
   manageDomElementActivation();
 }
 

--- a/test/e2e/custom_vendors_notification_test.js
+++ b/test/e2e/custom_vendors_notification_test.js
@@ -1,0 +1,29 @@
+import { CUSTOM_VENDOR_ONE_ELEMENT, CUSTOM_VENDOR_TWO_ELEMENT, OIL_YES_BUTTON } from '../test_constants';
+
+module.exports = {
+  '@disabled': false,
+  beforeEach: browser => {
+    browser
+      .deleteCookies();
+  },
+
+  'Notifies custom vendors in list if consent is given': function (browser) {
+    browser
+      .url(browser.globals.launch_url_host1 + 'demos/custom-vendors-notification.html')
+      .useXpath()
+      .pause(500)
+      .waitForElementPresent(CUSTOM_VENDOR_ONE_ELEMENT)
+      .assert.containsText(CUSTOM_VENDOR_ONE_ELEMENT, 'Custom Vendor 1 was opted out')
+      .waitForElementPresent(CUSTOM_VENDOR_TWO_ELEMENT)
+      .assert.containsText(CUSTOM_VENDOR_TWO_ELEMENT, 'Custom Vendor 2 was opted out')
+      .waitForElementPresent(OIL_YES_BUTTON, 15000, false)
+      .click(OIL_YES_BUTTON)
+      .pause(500)
+      .waitForElementPresent(CUSTOM_VENDOR_ONE_ELEMENT)
+      .assert.containsText(CUSTOM_VENDOR_ONE_ELEMENT, 'Custom Vendor 1 was opted in')
+      .waitForElementPresent(CUSTOM_VENDOR_TWO_ELEMENT)
+      .assert.containsText(CUSTOM_VENDOR_TWO_ELEMENT, 'Custom Vendor 2 was opted in')
+      .end();
+  }
+
+};

--- a/test/specs/core/core_oil.spec.js
+++ b/test/specs/core/core_oil.spec.js
@@ -4,6 +4,7 @@ import * as UserView from '../../../src/scripts/userview/locale/userview_oil';
 import * as CoreCommandCollection from '../../../src/scripts/core/core_command_collection';
 import * as CoreOptIn from '../../../src/scripts/core/core_optin';
 import * as CoreTagManagement from '../../../src/scripts/core/core_tag_management';
+import * as CoreCustomVendors from '../../../src/scripts/core/core_custom_vendors';
 import { waitsForAndRuns } from '../../test-utils/utils_wait';
 import { resetOil } from '../../test-utils/utils_reset';
 import { triggerEvent } from '../../test-utils/utils_events';
@@ -91,6 +92,36 @@ describe('core_oil', () => {
       }, () => {
         expect(CoreCommandCollection.executeCommandCollection).not.toHaveBeenCalled();
         expect(CoreUtils.setGlobalOilObject).toHaveBeenCalledWith('commandCollectionExecutor', executeCommandCollectionSpy);
+        done();
+      },
+      2000);
+  });
+
+  it('should send consent information to custom vendors if opt-in is provided', (done) => {
+    spyOn(CoreCustomVendors, 'sendConsentInformationToCustomVendors').and.returnValue(Promise.resolve());
+    spyOn(CoreOptIn, 'checkOptIn').and.returnValue(Promise.resolve(true));
+
+    initOilLayer();
+
+    waitsForAndRuns(
+      () => CoreCustomVendors.sendConsentInformationToCustomVendors.calls.count() > 0,
+      () => {
+        expect(CoreCustomVendors.sendConsentInformationToCustomVendors).toHaveBeenCalled();
+        done();
+      },
+      2000);
+  });
+
+  it('should send consent information to custom vendors if opt-in is not provided', (done) => {
+    spyOn(CoreCustomVendors, 'sendConsentInformationToCustomVendors').and.returnValue(Promise.resolve());
+    spyOn(CoreOptIn, 'checkOptIn').and.returnValue(Promise.resolve(false));
+
+    initOilLayer();
+
+    waitsForAndRuns(
+      () => CoreCustomVendors.sendConsentInformationToCustomVendors.calls.count() > 0,
+      () => {
+        expect(CoreCustomVendors.sendConsentInformationToCustomVendors).toHaveBeenCalled();
         done();
       },
       2000);

--- a/test/specs/core/core_optout.spec.js
+++ b/test/specs/core/core_optout.spec.js
@@ -1,0 +1,62 @@
+import { handleOptOut } from '../../../src/scripts/core/core_optout';
+import * as CoreCookies from '../../../src/scripts/core/core_cookies'
+import * as CorePoi from '../../../src/scripts/core/core_poi'
+import * as CoreUtils from '../../../src/scripts/core/core_utils'
+import * as CoreCommandCollection from '../../../src/scripts/core/core_command_collection'
+import * as CoreCustomVendors from '../../../src/scripts/core/core_custom_vendors'
+import * as CoreTagManager from '../../../src/scripts/core/core_tag_management'
+import { waitsForAndRuns } from '../../test-utils/utils_wait';
+import { EVENT_NAME_OPT_OUT } from '../../../src/scripts/core/core_constants';
+
+describe('Opt Out', () => {
+
+  it('removes subscriber cookies', () => {
+    spyOn(CoreCookies, 'removeSubscriberCookies').and.callThrough();
+
+    handleOptOut();
+
+    expect(CoreCookies.removeSubscriberCookies).toHaveBeenCalled();
+  });
+
+  it('deactivates power opt-in', (done) => {
+    spyOn(CorePoi, 'deActivatePowerOptIn').and.returnValue(Promise.resolve());
+    spyOn(CoreUtils, 'sendEventToHostSite').and.callThrough();
+
+    handleOptOut();
+
+    waitsForAndRuns(
+      () => CoreUtils.sendEventToHostSite.calls.count() > 0,
+      () => {
+        expect(CorePoi.deActivatePowerOptIn).toHaveBeenCalled();
+        expect(CoreUtils.sendEventToHostSite).toHaveBeenCalledWith(EVENT_NAME_OPT_OUT);
+        done();
+      },
+      2000
+    );
+  });
+
+  it('executes command collection', () => {
+    spyOn(CoreCommandCollection, 'executeCommandCollection').and.callThrough();
+
+    handleOptOut();
+
+    expect(CoreCommandCollection.executeCommandCollection).toHaveBeenCalled();
+  });
+
+  it('sends consent information to custom vendors', () => {
+    spyOn(CoreCustomVendors, 'sendConsentInformationToCustomVendors').and.returnValue(Promise.resolve());
+
+    handleOptOut();
+
+    expect(CoreCustomVendors.sendConsentInformationToCustomVendors).toHaveBeenCalled();
+  });
+
+  it('invokes soft blocking of oil-managed tags', () => {
+    spyOn(CoreTagManager, 'manageDomElementActivation').and.callThrough();
+
+    handleOptOut();
+
+    expect(CoreTagManager.manageDomElementActivation).toHaveBeenCalled();
+  });
+
+});

--- a/test/specs/userview/locale/userview_oil.spec.js
+++ b/test/specs/userview/locale/userview_oil.spec.js
@@ -144,8 +144,6 @@ describe('the locale fetcher for user view modal', () => {
   });
 
   it('should update existing but incomplete locale from configuration by default locale in case of non-existing locale url', (done) => {
-    console.info('##### RUNNING TEST #####');
-
     const configuredLocale = removeKeysFromLocale(COMPLETE_LOCALE, [OIL_LABELS.ATTR_LABEL_INTRO_HEADING, OIL_LABELS.ATTR_LABEL_BUTTON_BACK, OIL_LABELS.ATTR_LABEL_CPC_PURPOSE_DESC]);
     const expectedLocale = addValuesToLocaleCopy(configuredLocale, {
       [OIL_LABELS.ATTR_LABEL_INTRO_HEADING]: DEFAULT_LOCALE.texts[OIL_LABELS.ATTR_LABEL_INTRO_HEADING],

--- a/test/specs/userview/userview_handle-optin.spec.js
+++ b/test/specs/userview/userview_handle-optin.spec.js
@@ -7,6 +7,7 @@ import * as UserviewOptIn from '../../../src/scripts/userview/userview_optin'
 import * as CorePoi from '../../../src/scripts/core/core_poi';
 import * as CoreCookies from '../../../src/scripts/core/core_cookies';
 import * as CoreTagManagement from '../../../src/scripts/core/core_tag_management';
+import * as CoreCustomVendors from '../../../src/scripts/core/core_custom_vendors';
 import { EVENT_NAME_POI_OPT_IN, EVENT_NAME_SOI_OPT_IN, PRIVACY_FULL_TRACKING, PRIVACY_MINIMUM_TRACKING } from '../../../src/scripts/core/core_constants';
 import { resetOil } from '../../test-utils/utils_reset';
 import { waitsForAndRuns } from '../../test-utils/utils_wait';
@@ -77,6 +78,7 @@ describe('the user view modal handles opt-in clicks on', () => {
     });
 
     it('should execute command collection executor', (done) => {
+      mockPowerOptInAndSingleOptIn();
       spyOn(CoreUtils, 'getGlobalOilObject').and.callThrough();
 
       CoreUtils.setGlobalOilObject('commandCollectionExecutor', () => {
@@ -84,6 +86,22 @@ describe('the user view modal handles opt-in clicks on', () => {
         done();
       });
       handleOptIn();
+    });
+
+    it('should send consent information to custom vendors', (done) => {
+      mockPowerOptInAndSingleOptIn();
+      spyOn(CoreCustomVendors, 'sendConsentInformationToCustomVendors').and.returnValue(Promise.resolve());
+
+      handleOptIn();
+
+      waitsForAndRuns(
+        () => CoreTagManagement.manageDomElementActivation.calls.count() > 0,
+        () => {
+          expect(CoreTagManagement.manageDomElementActivation).toHaveBeenCalled();
+          expect(CoreCustomVendors.sendConsentInformationToCustomVendors).toHaveBeenCalled();
+          done();
+        },
+        2000);
     });
 
     it('should activate dom elements with consent', (done) => {
@@ -172,6 +190,23 @@ describe('the user view modal handles opt-in clicks on', () => {
         done();
       });
       handleOptIn();
+    });
+
+    it('should send consent information to custom vendors', (done) => {
+      mockPowerOptInAndSingleOptIn();
+      spyOn(CoreCustomVendors, 'sendConsentInformationToCustomVendors').and.returnValue(Promise.resolve());
+      loadFixture('poi/poi.default.html');
+
+      handleOptIn();
+
+      waitsForAndRuns(
+        () => CoreTagManagement.manageDomElementActivation.calls.count() > 0,
+        () => {
+          expect(CoreTagManagement.manageDomElementActivation).toHaveBeenCalled();
+          expect(CoreCustomVendors.sendConsentInformationToCustomVendors).toHaveBeenCalled();
+          done();
+        },
+        2000);
     });
 
     it('should activate dom elements with consent', (done) => {

--- a/test/test_constants.js
+++ b/test/test_constants.js
@@ -29,6 +29,8 @@ export const OIL_ADVANCED_SETTINGS_CUSTOM_PURPOSE_HEADER = '//*[@id="as-oil-cpc"
 export const OIL_MANAGED_TAGS_SCRIPT_TAG = '//*[@id="managedScriptTag"]';
 export const OIL_MANAGED_TAGS_IMG_TAG = '//*[@id="managedImgTag"]';
 export const OIL_MANAGED_TAGS_DIV = '//*[@id="demoText"]';
+export const CUSTOM_VENDOR_ONE_ELEMENT = '//*[@id="customVendor1DependentElement"]';
+export const CUSTOM_VENDOR_TWO_ELEMENT = '//*[@id="customVendor2DependentElement"]';
 export const PAGE_BACKGROUND = '.has-big-bad-background';
 export const VENDOR_INTEGRATION_IFRAME_ID = 'vendor-integration-iframe';
 export const VENDOR_INTEGRATION_IFRAME = `//*[@id="${VENDOR_INTEGRATION_IFRAME_ID}"]`;


### PR DESCRIPTION
End-to-end test for custom vendor notification.

The idea behind the test:
We use a special demo site for custom vendor notification (custom-vendors-notification.html). This demo site configures the opt-in layer to use the custom vendor list from https://www.oiljs.org/customvendors-example.json. This custom vendor list example is maintained within the [oil-website](https://github.com/as-ideas/oil-website) repository. I extended this example by some opt-in and opt-out JavaScript snippets for both contained custom vendors. These snippets change the values of two global JavaScript variables.
The demo site used for the test contains a JavaScript routine that is automatically invoked every 500 milliseconds. It checks the global variables changed by the custom vendor code snippets and shows corresponding texts on the site.
The end-to-end test invokes this demo page, checks the shown texts, clicks the opt-in layer's OK button (gives consent) and checks the change of the shown texts.