### PR TITLE
OIL-358: AMP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ For detailed explanations, please visit the [documentation](https://oil.axelspri
 | iabVendorBlacklist | Array of vendor IDs to exclude. | None
 | iabVendorListUrl | URL of the list of vendors to use | https://vendorlist.consensu.org/vendorlist.json
 | iabVendorWhitelist | Array of vendor IDs to allow. If it is set, values in `iabVendorBlacklist` are ignored. | None
+| info_banner_only | Deactivates calculating of consent string | false
 | locale | Object including locale version, id and labels. You can define the standard labels for all legal texts and buttons and set a version for it. See [here for a configuration example](#texts-locale-object) and [here for all localizable labels](#available-text-labels) | None
 | locale_url | As an alternative to passing a locale object, set this to a JSON file with the locale configuration. See [here for an example file](https://github.com/as-ideas/oil/blob/master/test/fixtures/config/deDE_01_locale.json) | None
 | persist_min_tracking | If minimum tracking should result in removing all OIL cookies from the users browser and close the layer and store this selection in the oil cookie. | True
@@ -171,9 +172,9 @@ For detailed explanations, please visit the [documentation](https://oil.axelspri
 | publicPath | The server path from which all chunks and ressources will be loaded. You should upload all released files there and configure it. | `//unpkg.com/@ideasio/oil.js@{oilVersion}/release/current/`
 | require_optout_confirm | Flag to activate the opt-out confirmation dialog within the CPC. If set to `true`, additional label definitions (with prefix `label_cpc_purpose_optout`) are required. See the label configuration section in the documentation for details. | false
 | show_limited_vendors_only | Flag to only show the vendors limited by `iabVendorWhitelist` or `iabVendorBlacklist` in the CPC | false
+| suppress_cookies | Deactivates cookie setting - useful for AMP pages only | false
 | theme | The theme for the layer. By default there are two themes, 'dark' and 'light', with 'light' beeing the default. The theme currently works only as an additional css class. If you want to change the style or theme, please look into the styling guide in the development section. | 'light'
 | timeout | Value in seconds until the opt-in layer will be automatically hidden. 0 or lower deactivates auto-hide. | 60
-| info_banner_only | Deactivates calculating of consent string | false
 
 ### Texts & Locale Object
 

--- a/docs/src/docs/03-configuration.adoc
+++ b/docs/src/docs/03-configuration.adoc
@@ -128,6 +128,7 @@ This is a full list of configurable options.
 | iabVendorBlacklist | Array of vendor IDs to exclude from consent. <<blacklisting-and-whitelisting, Details here>> | None
 | iabVendorListUrl | Vendorlist to use | https://vendorlist.consensu.org/vendorlist.json
 | iabVendorWhitelist | Array of vendor IDs to include in consent. If it is set, values in `iabVendorBlacklist` are ignored. <<blacklisting-and-whitelisting, Details here>>. When white- or blacklisting you might also be interested in the `show_limited_vendors_only` parameter. | None
+| info_banner_only | Deactivates calculating of consent string and sets consent cookie if timeout is defined and expired | false
 | <<texts-locale-object,locale>> | Object including locale version, id and labels. You can define the standard labels for all legal texts and buttons and set a version for it. <<locale-object, See here for details>> | None
 | locale_url | As an alternative to passing a locale object, set this to a JSON file with the locale configuration. See link:https://github.com/as-ideas/oil/blob/master/test/fixtures/config/deDE_01_locale.json[See here for an example file] | None
 | persist_min_tracking | If minimum tracking should result in removing all OIL cookies from the users browser and close the layer and store this selection in the oil cookie. | true
@@ -139,9 +140,9 @@ This is a full list of configurable options.
 | publicPath | The server path from which all chunks and resources will be loaded. You should upload all released files there and configure it. | `https://unpkg.com/@ideasio/oil.js@{version}/release/current/`
 | require_optout_confirm | Flag to activate the opt-out confirmation dialog within Cookie Preference Center. If set to `true`, addition label definitions (for labels with prefix `label_cpc_purpose_optout_confirm`) are required. See section <<Language label configuration>> for details. | false
 | show_limited_vendors_only | Flag to only show the vendors limited by `iabVendorWhitelist` or `iabVendorBlacklist` in the CPC | false
+| suppress_cookies | Deactivates cookie setting - useful for AMP pages only | false
 | theme | The theme for the layer. By default there are two themes and size modifier themes, `dark` and `light` as well as `small dark` and `small light`. Themes currently work only as an additional css class. To change the style or theme, look into the <<styling-guide,styling guide>>. | light
 | <<auto-hiding-the-layer-timeout,timeout>> | Value in seconds until the opt-in layer will be automatically hidden. 0 or lower deactivates auto-hide. | 60
-| info_banner_only | Deactivates calculating of consent string and sets consent cookie if timeout is defined and expired | false
 |====
 
 === Texts & Locale Object

--- a/docs/src/docs/07-amp-consent.adoc
+++ b/docs/src/docs/07-amp-consent.adoc
@@ -4,7 +4,7 @@ To exchange user consent for your POI group with an AMP page, you want to make u
 
 === Technical integration
 
-1. Copy the file `demos/amp-consent-iframe.html` and update it with your own oil-configuration.
+1. Copy the file `demos/amp-consent-iframe.html` and update it with your own oil-configuration. (You can adapt configuration for your needs. Please do not change settings for `info_banner_only` and `suppress_cookies`.)
 2. Upload the file to the server where the POI cookie should be stored. This should be the same one that you have configured in the `poi_hub_origin` configuration parameter. Make sure the file is accessible through a secure (SSL) connection.
 3. Include the path to the iframe within your `amp-consent` dialog. Ex.:
 [source,html]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ideasio/oil.js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/demos/amp-consent-iframe.html
+++ b/src/demos/amp-consent-iframe.html
@@ -7,7 +7,7 @@
 {
   "config_version": 1,
   "poi_group_name": "axelSpringerSe_01",
-  "timeout": -1,
+  "timeout": 10,
   "info_banner_only": true,
   "suppress_cookies": true
 }

--- a/src/demos/amp-consent-iframe.html
+++ b/src/demos/amp-consent-iframe.html
@@ -7,7 +7,9 @@
 {
   "config_version": 1,
   "poi_group_name": "axelSpringerSe_01",
-  "timeout": -1
+  "timeout": -1,
+  "info_banner_only": true,
+  "suppress_cookies": true
 }
 
   </script>

--- a/src/demos/amp-consent.html
+++ b/src/demos/amp-consent.html
@@ -43,7 +43,7 @@
   </script>
   <amp-iframe id="consentDialog" class="lightbox-content" height="100" width="100" layout="responsive"
               sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-              src="https://oil-cdn.herokuapp.com/demos/amp-consent-iframe.html">
+              src="https://oil-integration-host1.herokuapp.com/demos/amp-consent-iframe.html">
     <div placeholder>Loading</div>
   </amp-iframe>
 </amp-consent>

--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -259,6 +259,16 @@ export function getShowLimitedVendors() {
   return getConfigValue(OIL_CONFIG.ATTR_SHOW_LIMITED_VENDORS_ONLY, false);
 }
 
-export function getInfoBannerOnly() {
+export function isInfoBannerOnly() {
   return getConfigValue(OIL_CONFIG.ATTR_INFO_BANNER_ONLY, false);
 }
+
+export function suppressCookies() {
+  return getConfigValue(OIL_CONFIG.ATTR_SUPPRESS_COOKIES, false);
+}
+
+export function isAmpModeActivated() {
+  return isInfoBannerOnly() && suppressCookies();
+}
+
+

--- a/src/scripts/core/core_constants.js
+++ b/src/scripts/core/core_constants.js
@@ -34,7 +34,8 @@ export const OIL_CONFIG = {
   ATTR_GDPR_APPLIES_GLOBALLY: 'gdpr_applies_globally',
   ATTR_GDPR_APPLIES: 'gdpr_applies',
   ATTR_REQUIRE_OPTOUT_CONFIRM: 'require_optout_confirm',
-  ATTR_INFO_BANNER_ONLY: 'info_banner_only'
+  ATTR_INFO_BANNER_ONLY: 'info_banner_only',
+  ATTR_SUPPRESS_COOKIES: 'suppress_cookies'
 };
 
 export const OIL_CONFIG_CPC_TYPES = {

--- a/src/scripts/core/core_cookies.js
+++ b/src/scripts/core/core_cookies.js
@@ -5,7 +5,7 @@ import {
   getCookieExpireInDays,
   getCustomPurposes,
   getDefaultToOptin,
-  getInfoBannerOnly,
+  isInfoBannerOnly,
   getLanguage,
   getLanguageFromLocale,
   getLocaleVariantName
@@ -90,7 +90,7 @@ export function setSoiCookieWithPoiCookieData(poiCookieJson) {
         localeVariantVersion: cookieConfig.defaultCookieContent.localeVariantVersion,
         customVendorListVersion: poiCookieJson.customVendorListVersion,
         customPurposes: poiCookieJson.customPurposes,
-        consentString: !getInfoBannerOnly() ? consentString : '',
+        consentString: !isInfoBannerOnly() ? consentString : '',
         configVersion: configVersion
       };
 
@@ -117,7 +117,7 @@ export function buildSoiCookie(privacySettings) {
         localeVariantVersion: cookieConfig.defaultCookieContent.localeVariantVersion,
         customVendorListVersion: getCustomVendorListVersion(),
         customPurposes: getCustomPurposesWithConsent(privacySettings),
-        consentString: !getInfoBannerOnly() ? consentData.getConsentString() : '',
+        consentString: !isInfoBannerOnly() ? consentData.getConsentString() : '',
         configVersion: cookieConfig.defaultCookieContent.configVersion
       };
 
@@ -279,7 +279,7 @@ function getOilCookieConfig() {
       localeVariantVersion: getLocaleVariantVersion(),
       customPurposes: getAllowedCustomPurposesDefault(),
       consentData: consentData,
-      consentString: !getInfoBannerOnly() ? consentData.getConsentString() : '',
+      consentString: !isInfoBannerOnly() ? consentData.getConsentString() : '',
       configVersion: getConfigVersion()
     },
     outdated_cookie_content_keys: ['opt_in', 'timestamp', 'version', 'localeVariantName', 'localeVariantVersion', 'privacy']
@@ -300,6 +300,6 @@ function transformOutdatedOilCookie(cookieConfig) {
   cookie.consentData.setPurposesAllowed(getStandardPurposesWithConsent(cookieJson.privacy));
   cookie.consentData.setVendorsAllowed(getLimitedVendorIds());
   cookie.consentData.setGlobalVendorList(getVendorList());
-  cookie.consentString = !getInfoBannerOnly() ? cookie.consentData.getConsentString() : '';
+  cookie.consentString = !isInfoBannerOnly() ? cookie.consentData.getConsentString() : '';
   return cookie;
 }

--- a/src/scripts/core/core_oil.js
+++ b/src/scripts/core/core_oil.js
@@ -4,7 +4,7 @@ import { logError, logInfo, logPreviewInfo } from './core_log';
 import { checkOptIn } from './core_optin';
 import { getSoiCookie, isBrowserCookieEnabled, isPreviewCookieSet, removePreviewCookie, removeVerboseCookie, setPreviewCookie, setVerboseCookie } from './core_cookies';
 import { doSetTealiumVariables } from './core_tealium_loading_rules';
-import { getLocale, isPreviewMode, resetConfiguration, setGdprApplies } from './core_config';
+import { getLocale, isAmpModeActivated, isPreviewMode, resetConfiguration, setGdprApplies } from './core_config';
 import { EVENT_NAME_HAS_OPTED_IN, EVENT_NAME_NO_COOKIES_ALLOWED } from './core_constants';
 import { executeCommandCollection } from './core_command_collection';
 import { manageDomElementActivation } from './core_tag_management';
@@ -34,7 +34,7 @@ export function initOilLayer() {
     /**
      * Cookies are not enabled
      */
-    if (!isBrowserCookieEnabled()) {
+    if (!isAmpModeActivated() && !isBrowserCookieEnabled()) {
       logInfo('This browser doesn\'t allow cookies.');
       import('../userview/locale/userview_oil.js')
         .then(userview_modal => {

--- a/src/scripts/core/core_tealium_loading_rules.js
+++ b/src/scripts/core/core_tealium_loading_rules.js
@@ -1,4 +1,4 @@
-import { getInfoBannerOnly } from './core_config';
+import { isInfoBannerOnly } from './core_config';
 import {getSoiCookie} from './core_cookies.js';
 
 
@@ -109,7 +109,7 @@ function reEvaluateTealiumLoadingRules() {
       [LOADING_RULE_PURPOSE_04]: ud[LOADING_RULE_PURPOSE_04],
       [LOADING_RULE_PURPOSE_05]: ud[LOADING_RULE_PURPOSE_05]
     };
-    if(!getInfoBannerOnly()) {
+    if(!isInfoBannerOnly()) {
       window.utag.view(payload);
     }
   }

--- a/src/scripts/userview/userview_modal.js
+++ b/src/scripts/userview/userview_modal.js
@@ -25,7 +25,7 @@ import * as AdvancedSettingsStandard from './view/oil.advanced.settings.standard
 import * as AdvancedSettingsTabs from './view/oil.advanced.settings.tabs';
 import { logError, logInfo } from '../core/core_log';
 import { getCpcType, getTheme, getTimeOutValue, isOptoutConfirmRequired, isPersistMinimumTracking } from './userview_config';
-import { gdprApplies, getAdvancedSettingsPurposesDefault, getInfoBannerOnly, isPoiActive } from '../core/core_config';
+import { gdprApplies, getAdvancedSettingsPurposesDefault, isInfoBannerOnly, isPoiActive } from '../core/core_config';
 import { applyPrivacySettings, getPrivacySettings, getSoiConsentData } from './userview_privacy';
 import { activateOptoutConfirm } from './userview_optout_confirm';
 import { getPurposeIds, loadVendorListAndCustomVendorList } from '../core/core_vendor_lists';
@@ -143,7 +143,7 @@ function startTimeOut() {
     hasRunningTimeout = setTimeout(function () {
       removeOilWrapperFromDOM();
       sendEventToHostSite(EVENT_NAME_TIMEOUT);
-      if(getInfoBannerOnly()) {
+      if(isInfoBannerOnly()) {
         handleOptIn();
       }
       hasRunningTimeout = undefined;

--- a/src/scripts/userview/userview_optin.js
+++ b/src/scripts/userview/userview_optin.js
@@ -5,7 +5,8 @@ import { sendEventToHostSite } from '../core/core_utils.js';
 import {
   EVENT_NAME_OPT_IN,
   OIL_PAYLOAD_CONFIG_VERSION,
-  OIL_PAYLOAD_CUSTOM_PURPOSES, OIL_PAYLOAD_CUSTOM_VENDORLIST_VERSION,
+  OIL_PAYLOAD_CUSTOM_PURPOSES,
+  OIL_PAYLOAD_CUSTOM_VENDORLIST_VERSION,
   OIL_PAYLOAD_LOCALE_VARIANT_NAME,
   OIL_PAYLOAD_LOCALE_VARIANT_VERSION,
   OIL_PAYLOAD_PRIVACY,
@@ -13,7 +14,7 @@ import {
   PRIVACY_FULL_TRACKING
 } from '../core/core_constants';
 import { setSoiCookie } from '../core/core_cookies';
-import { isInfoBannerOnly, isPoiActive } from '../core/core_config';
+import { isAmpModeActivated, isInfoBannerOnly, isPoiActive } from '../core/core_config';
 
 /**
  * Oil optIn power
@@ -22,6 +23,9 @@ import { isInfoBannerOnly, isPoiActive } from '../core/core_config';
  * @return Promise with updated cookie value
  */
 export function oilPowerOptIn(privacySettings) {
+  if (isAmpModeActivated()) {
+    return Promise.resolve(true);
+  }
   return new Promise((resolve, reject) => {
     let soiCookiePromise;
     // Update Oil cookie (site - SOI)
@@ -65,6 +69,9 @@ export function oilPowerOptIn(privacySettings) {
  * @return {Promise} promise with updated cookie value
  */
 export function oilOptIn(privacySettings = PRIVACY_FULL_TRACKING) {
+  if (isAmpModeActivated()) {
+    return Promise.resolve(true);
+  }
   return new Promise((resolve, reject) => {
     setSoiCookie(privacySettings).then(() => {
       sendEventToHostSite(EVENT_NAME_OPT_IN);

--- a/src/scripts/userview/userview_optin.js
+++ b/src/scripts/userview/userview_optin.js
@@ -13,7 +13,7 @@ import {
   PRIVACY_FULL_TRACKING
 } from '../core/core_constants';
 import { setSoiCookie } from '../core/core_cookies';
-import { getInfoBannerOnly, isPoiActive } from '../core/core_config';
+import { isInfoBannerOnly, isPoiActive } from '../core/core_config';
 
 /**
  * Oil optIn power
@@ -28,7 +28,7 @@ export function oilPowerOptIn(privacySettings) {
     soiCookiePromise = setSoiCookie(privacySettings);
     soiCookiePromise.then((cookie) => {
       let payload = {
-        [OIL_PAYLOAD_PRIVACY]: !getInfoBannerOnly() ? cookie.consentString : '',
+        [OIL_PAYLOAD_PRIVACY]: !isInfoBannerOnly() ? cookie.consentString : '',
         [OIL_PAYLOAD_VERSION]: cookie.version,
         [OIL_PAYLOAD_LOCALE_VARIANT_NAME]: cookie.localeVariantName,
         [OIL_PAYLOAD_LOCALE_VARIANT_VERSION]: cookie.localeVariantVersion,

--- a/test/fixtures/config/full.config.html
+++ b/test/fixtures/config/full.config.html
@@ -18,6 +18,7 @@
   "poi_subscriber_set_cookie": true,
   "cookie_expires_in_days": true,
   "publicPath": "//www.com",
-  "info_banner_only": true
+  "info_banner_only": true,
+  "suppress_cookies": true
 }
 </script>

--- a/test/fixtures/config/given.config.with.infoBannerMode.activated.and.cookieSetting.not.suppressed.html
+++ b/test/fixtures/config/given.config.with.infoBannerMode.activated.and.cookieSetting.not.suppressed.html
@@ -1,0 +1,7 @@
+<script id="oil-configuration" type="application/configuration">
+    {
+      "config_version": 1,
+      "info_banner_only": true,
+      "suppress_cookies": false
+    }
+</script>

--- a/test/fixtures/config/given.config.with.infoBannerMode.activated.and.cookieSetting.suppressed.html
+++ b/test/fixtures/config/given.config.with.infoBannerMode.activated.and.cookieSetting.suppressed.html
@@ -1,0 +1,7 @@
+<script id="oil-configuration" type="application/configuration">
+    {
+      "config_version": 1,
+      "info_banner_only": true,
+      "suppress_cookies": true
+    }
+</script>

--- a/test/fixtures/config/given.config.with.infoBannerMode.deactivated.html
+++ b/test/fixtures/config/given.config.with.infoBannerMode.deactivated.html
@@ -1,0 +1,6 @@
+<script id="oil-configuration" type="application/configuration">
+    {
+      "config_version": 1,
+      "info_banner_only": false
+    }
+</script>

--- a/test/specs/core/core_config.spec.js
+++ b/test/specs/core/core_config.spec.js
@@ -10,7 +10,6 @@ import {
   getHubPath,
   getIabVendorBlacklist,
   getIabVendorWhitelist,
-  isInfoBannerOnly,
   getLanguageFromLocale,
   getLocale,
   getLocaleUrl,
@@ -19,8 +18,11 @@ import {
   getPoiListDirectory,
   getPublicPath,
   getShowLimitedVendors,
+  isAmpModeActivated,
+  isInfoBannerOnly,
   setGdprApplies,
-  setLocale
+  setLocale,
+  suppressCookies
 } from '../../../src/scripts/core/core_config';
 import { loadFixture } from '../../test-utils/utils_fixtures';
 import * as CoreLog from '../../../src/scripts/core/core_log';
@@ -142,6 +144,7 @@ describe('core_config', () => {
       expect(getCookieExpireInDays()).toEqual(true);
       expect(getPoiGroupName()).toEqual(true);
       expect(isInfoBannerOnly()).toEqual(true);
+      expect(suppressCookies()).toEqual(true);
     });
 
     it('should return correct default values', function () {
@@ -156,6 +159,7 @@ describe('core_config', () => {
       expect(getCookieExpireInDays()).toEqual(DEFAULT_COOKIE_EXPIRES_IN);
       expect(getPoiGroupName()).toEqual(DEFAULT_POI_GROUP);
       expect(isInfoBannerOnly()).toEqual(false);
+      expect(suppressCookies()).toEqual(false);
     });
 
   });
@@ -268,6 +272,24 @@ describe('core_config', () => {
       expect(getPoiListDirectory()).toEqual('/poi-lists');
     });
 
+  });
+
+  describe('isAmpModeActivated', () => {
+
+    it('returns true if info banner mode is activated and cookies are suppressed', () => {
+      loadFixture('config/given.config.with.infoBannerMode.activated.and.cookieSetting.suppressed.html');
+      expect(isAmpModeActivated()).toBeTruthy();
+    });
+
+    it('returns false if info banner mode is deactivated', () => {
+      loadFixture('config/given.config.with.infoBannerMode.deactivated.html');
+      expect(isAmpModeActivated()).toBeFalsy();
+    });
+
+    it('returns false if info banner mode is activated but cookie setting is allowed', () => {
+      loadFixture('config/given.config.with.infoBannerMode.activated.and.cookieSetting.not.suppressed.html');
+      expect(isAmpModeActivated()).toBeFalsy();
+    });
   });
 
 });

--- a/test/specs/core/core_config.spec.js
+++ b/test/specs/core/core_config.spec.js
@@ -10,7 +10,7 @@ import {
   getHubPath,
   getIabVendorBlacklist,
   getIabVendorWhitelist,
-  getInfoBannerOnly,
+  isInfoBannerOnly,
   getLanguageFromLocale,
   getLocale,
   getLocaleUrl,
@@ -141,7 +141,7 @@ describe('core_config', () => {
       expect(getLocaleUrl()).toEqual(true);
       expect(getCookieExpireInDays()).toEqual(true);
       expect(getPoiGroupName()).toEqual(true);
-      expect(getInfoBannerOnly()).toEqual(true);
+      expect(isInfoBannerOnly()).toEqual(true);
     });
 
     it('should return correct default values', function () {
@@ -155,7 +155,7 @@ describe('core_config', () => {
       expect(getLocaleUrl()).toBeUndefined();
       expect(getCookieExpireInDays()).toEqual(DEFAULT_COOKIE_EXPIRES_IN);
       expect(getPoiGroupName()).toEqual(DEFAULT_POI_GROUP);
-      expect(getInfoBannerOnly()).toEqual(false);
+      expect(isInfoBannerOnly()).toEqual(false);
     });
 
   });

--- a/test/specs/core/core_cookies.spec.js
+++ b/test/specs/core/core_cookies.spec.js
@@ -221,7 +221,7 @@ describe('core cookies', () => {
     });
 
     it('should set simple soi cookie without consent info if config info_banner_only is true', (done) => {
-      spyOn(CoreConfig, 'getInfoBannerOnly').and.returnValue(true);
+      spyOn(CoreConfig, 'isInfoBannerOnly').and.returnValue(true);
 
       setSoiCookie(1).then(() => {
         const cookieSetArguments = Cookie.set.calls.argsFor(0);

--- a/test/specs/core/core_oil.spec.js
+++ b/test/specs/core/core_oil.spec.js
@@ -5,9 +5,12 @@ import * as CoreCommandCollection from '../../../src/scripts/core/core_command_c
 import * as CoreOptIn from '../../../src/scripts/core/core_optin';
 import * as CoreTagManagement from '../../../src/scripts/core/core_tag_management';
 import * as CoreCustomVendors from '../../../src/scripts/core/core_custom_vendors';
+import * as CoreCookies from '../../../src/scripts/core/core_cookies';
+import * as CoreConfig from '../../../src/scripts/core/core_config';
 import { waitsForAndRuns } from '../../test-utils/utils_wait';
 import { resetOil } from '../../test-utils/utils_reset';
 import { triggerEvent } from '../../test-utils/utils_events';
+import { EVENT_NAME_NO_COOKIES_ALLOWED } from '../../../src/scripts/core/core_constants';
 
 describe('core_oil', () => {
 
@@ -136,6 +139,57 @@ describe('core_oil', () => {
       () => CoreTagManagement.manageDomElementActivation.calls.count() > 0,
       () => {
         expect(CoreTagManagement.manageDomElementActivation).toHaveBeenCalledTimes(1);
+        done();
+      },
+      2000);
+  });
+
+  it('should perform successful cookie check if amp mode is deactivated and cookies are enabled', (done) => {
+    spyOn(CoreCookies, 'isBrowserCookieEnabled').and.returnValue(true);
+    spyOn(CoreConfig, 'isAmpModeActivated').and.returnValue(false);
+    spyOn(CoreUtils, 'sendEventToHostSite');
+    spyOn(UserView, 'locale');
+
+    initOilLayer();
+    waitsForAndRuns(
+      () => CoreCookies.isBrowserCookieEnabled.calls.count() > 0,
+      () => {
+        expect(CoreCookies.isBrowserCookieEnabled).toHaveBeenCalled();
+        expect(CoreUtils.sendEventToHostSite).not.toHaveBeenCalledWith(EVENT_NAME_NO_COOKIES_ALLOWED);
+        done();
+      },
+      2000);
+  });
+
+  it('should perform unsuccessful cookie check if amp mode is deactivated and cookies are disabled', (done) => {
+    spyOn(CoreCookies, 'isBrowserCookieEnabled').and.returnValue(false);
+    spyOn(CoreConfig, 'isAmpModeActivated').and.returnValue(false);
+    spyOn(CoreUtils, 'sendEventToHostSite');
+    spyOn(UserView, 'locale');
+
+    initOilLayer();
+    waitsForAndRuns(
+      () => CoreCookies.isBrowserCookieEnabled.calls.count() > 0,
+      () => {
+        expect(CoreCookies.isBrowserCookieEnabled).toHaveBeenCalled();
+        expect(CoreUtils.sendEventToHostSite).toHaveBeenCalledWith(EVENT_NAME_NO_COOKIES_ALLOWED);
+        done();
+      },
+      2000);
+  });
+
+  it('should not perform cookie check if amp mode is activated', (done) => {
+    spyOn(CoreCookies, 'isBrowserCookieEnabled');
+    spyOn(CoreConfig, 'isAmpModeActivated').and.returnValue(true);
+    spyOn(CoreUtils, 'sendEventToHostSite');
+    spyOn(UserView, 'locale');
+
+    initOilLayer();
+    waitsForAndRuns(
+      () => CoreConfig.isAmpModeActivated.calls.count() > 0,
+      () => {
+        expect(CoreCookies.isBrowserCookieEnabled).not.toHaveBeenCalled();
+        expect(CoreUtils.sendEventToHostSite).not.toHaveBeenCalledWith(EVENT_NAME_NO_COOKIES_ALLOWED);
         done();
       },
       2000);

--- a/test/specs/userview/userview_optin.spec.js
+++ b/test/specs/userview/userview_optin.spec.js
@@ -36,6 +36,40 @@ describe('user view opt-in handler', () => {
 
   beforeEach(() => resetOil());
 
+  describe('cookie set prevention in amp mode', () => {
+
+    beforeEach(() => {
+      spyOn(CoreConfig, 'isAmpModeActivated').and.returnValue(true);
+      spyOn(UserViewPoi, 'activatePowerOptInWithIFrame');
+      spyOn(UserViewPoi, 'activatePowerOptInWithRedirect');
+      spyOn(CoreCookies, 'setSoiCookie');
+      spyOn(CorePoi, 'verifyPowerOptIn');
+      spyOn(CoreUtils, 'sendEventToHostSite');
+    });
+
+    it('should prevent power optin setting if amp mode is activated', (done) => {
+      oilPowerOptIn(PRIVACY_SETTINGS).then((result) => {
+        expect(CoreCookies.setSoiCookie).not.toHaveBeenCalled();
+        expect(UserViewPoi.activatePowerOptInWithIFrame).not.toHaveBeenCalled();
+        expect(UserViewPoi.activatePowerOptInWithRedirect).not.toHaveBeenCalled();
+        expect(CorePoi.verifyPowerOptIn).not.toHaveBeenCalled();
+        expect(CoreUtils.sendEventToHostSite).not.toHaveBeenCalled();
+        expect(result).toBe(true);
+        done();
+      });
+    });
+
+    it('should prevent single optin setting if amp mode is activated', (done) => {
+      oilOptIn(PRIVACY_SETTINGS).then((result) => {
+        expect(CoreCookies.setSoiCookie).not.toHaveBeenCalled();
+        expect(CoreUtils.sendEventToHostSite).not.toHaveBeenCalled();
+        expect(result).toBe(true);
+        done();
+      });
+    });
+
+  });
+
   describe('power opt-in handler', () => {
     let expectedLocaleVariantName = 'enEN_01';
     let expectedLocaleVariantVersion = 17;
@@ -44,6 +78,7 @@ describe('user view opt-in handler', () => {
       spyOn(UserViewPoi, 'activatePowerOptInWithIFrame');
       spyOn(UserViewPoi, 'activatePowerOptInWithRedirect');
       spyOn(CoreConfig, 'getLocaleVariantName').and.returnValue(expectedLocaleVariantName);
+      spyOn(CoreConfig, 'isAmpModeActivated').and.returnValue(false);
       spyOn(CoreCookies, 'setSoiCookie').and.returnValue(new Promise((resolve) => resolve(EXPECTED_COOKIE)));
       spyOn(CoreCookies, 'buildSoiCookie').and.returnValue(new Promise((resolve) => resolve(EXPECTED_COOKIE)));
       spyOn(CoreUtils, 'getLocaleVariantVersion').and.returnValue(expectedLocaleVariantVersion);
@@ -150,6 +185,7 @@ describe('user view opt-in handler', () => {
   describe('single opt-in handler', () => {
 
     beforeEach(() => {
+      spyOn(CoreConfig, 'isAmpModeActivated').and.returnValue(false);
       spyOn(CoreUtils, 'sendEventToHostSite');
       spyOn(CoreCookies, 'setSoiCookie').and.returnValue(new Promise((resolve) => resolve(EXPECTED_COOKIE)));
     });

--- a/test/specs/userview/userview_optin.spec.js
+++ b/test/specs/userview/userview_optin.spec.js
@@ -75,7 +75,7 @@ describe('user view opt-in handler', () => {
 
     it('should activate power opt-in with iframe without consent string for info_banner_only', (done) => {
       spyOn(CoreConfig, 'isPoiActive').and.returnValue(true);
-      spyOn(CoreConfig, 'getInfoBannerOnly').and.returnValue(true);
+      spyOn(CoreConfig, 'isInfoBannerOnly').and.returnValue(true);
 
       const EXPECTED_COOKIE = {
         opt_in: true,


### PR DESCRIPTION
- add amp mode configuration (additional config parameter 'suppress_cookies')
- prevent cookie check in activated amp mode
- prevent cookie setting in activated amp mode