### PR TITLE
Add option to set the domain of the SOI cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For detailed explanations, please visit the [documentation](https://oil.axelspri
 | advanced_settings | Replaces the No Button with an advanced settings button, displaying the Cookie Preference Center. The CPC enables the user to choose their own level of privacy. These settings are stored in the oil cookie (both SOI and POI) as well. | False
 | advanced_settings_purposes_default | All purposes in the advanced settings layer should be activated by default | false
 | config_version | Specifies the version of your OIL configuration. It will be stored with the consent cookie to track which explicit configuration version consent was granted for.| None
+| cookie_domain | Specifies the domain to write the cookie to.  Can be used to set the cookie on a valid parent domain: e.g sub.example.com -> .example.com. | Current hostname
 | cookie_expires_in_days | Value in days until the domain cookie used to save the users decision in days | 31
 | cpc_type | Specifies the type (the layout) of the Cookie Preference Center. Currently, two types are supported: 'standard' and 'tabs'. Depending on this parameter additional label configuration may be necessary. See section <<Full Label Configuration>> for details. | standard
 | customPurposes | Array of custom purposes defined by publisher. IDs for custom purposes may range from 25-88. | None

--- a/docs/src/docs/03-configuration.adoc
+++ b/docs/src/docs/03-configuration.adoc
@@ -120,6 +120,7 @@ This is a full list of configurable options.
 | advanced_settings_purposes_default | All purposes in the advanced settings layer should be activated by default | false
 | config_version | Specifies the version of your OIL configuration. It will be stored with the consent cookie to track which explicit configuration version consent was granted for.| None
 | cookie_expires_in_days | Value in days until the domain cookie used to save the users decision in days | 31
+| cookie_domain | Specifies the domain to write the cookie to.  Can be used to set the cookie on a valid parent domain: e.g sub.example.com -> .example.com. | Current hostname
 | cpc_type | Specifies the type (the layout) of the Cookie Preference Center. Currently, two types are supported: 'standard' and 'tabs'. Depending on this parameter additional label configuration may be necessary. See section <<Full Label Configuration>> for details. | standard
 | customPurposes | Array of custom purposes defined by publisher. IDs for custom purposes may range from 25-88. | None
 | customVendorListUrl | Custom vendor list ('non IAB vendors') to use, will be loaded at the same time as the iabVendorList. | None

--- a/src/scripts/core/core_config.js
+++ b/src/scripts/core/core_config.js
@@ -173,6 +173,10 @@ export function getCookieExpireInDays() {
   return getConfigValue(OIL_CONFIG.ATTR_COOKIE_EXPIRES_IN_DAYS, 31);
 }
 
+export function getCookieDomain() {
+  return getConfigValue(OIL_CONFIG.ATTR_COOKIE_DOMAIN, '');
+}
+
 export function getLocaleVariantName() {
   const defaultLocaleId = 'enEN_01';
   let localeVariantName = getLocale();

--- a/src/scripts/core/core_constants.js
+++ b/src/scripts/core/core_constants.js
@@ -13,6 +13,7 @@ export const OIL_CONFIG = {
   ATTR_HUB_LOCATION: 'poi_hub_location', // complete hub location, gets generated
   ATTR_PREVIEW_MODE: 'preview_mode',
   ATTR_COOKIE_EXPIRES_IN_DAYS: 'cookie_expires_in_days',
+  ATTR_COOKIE_DOMAIN: 'cookie_domain',
   ATTR_TIMESTAMP: 'timestamp',
   ATTR_PRIVACY_PAGE_URL: 'privacy_page_url',
   ATTR_POI_GROUP_NAME: 'poi_group_name',

--- a/src/scripts/core/core_cookies.js
+++ b/src/scripts/core/core_cookies.js
@@ -3,6 +3,7 @@ import { logInfo } from './core_log';
 import {
   getConfigVersion,
   getCookieExpireInDays,
+  getCookieDomain,
   getCustomPurposes,
   getDefaultToOptin,
   isInfoBannerOnly,
@@ -27,10 +28,10 @@ export function setSessionCookie(name, value) {
   Cookie.set(name, value);
 }
 
-export function setDomainCookie(name, value, expires_in_days) {
+export function setDomainCookie(name, value, expires_in_days, domain) {
   // decoded consent data must not be written to the cookie
   delete value.consentData;
-  Cookie.set(name, value, { expires: expires_in_days });
+  Cookie.set(name, value, { expires: expires_in_days, domain: domain });
 }
 
 export function getOilCookie(cookieConfig) {
@@ -94,7 +95,7 @@ export function setSoiCookieWithPoiCookieData(poiCookieJson) {
         configVersion: configVersion
       };
 
-      setDomainCookie(cookieConfig.name, cookie, cookieConfig.expires);
+      setDomainCookie(cookieConfig.name, cookie, cookieConfig.expires, cookieConfig.domain);
       resolve(cookie);
     }).catch(error => reject(error));
   });
@@ -129,7 +130,7 @@ export function buildSoiCookie(privacySettings) {
 export function setSoiCookie(privacySettings) {
   return new Promise((resolve, reject) => {
     buildSoiCookie(privacySettings).then((cookie) => {
-      setDomainCookie(OIL_DOMAIN_COOKIE_NAME, cookie, getCookieExpireInDays());
+      setDomainCookie(OIL_DOMAIN_COOKIE_NAME, cookie, getCookieExpireInDays(), getCookieDomain());
       resolve(cookie);
     }).catch(error => reject(error));
   });
@@ -272,6 +273,7 @@ function getOilCookieConfig() {
   return {
     name: OIL_DOMAIN_COOKIE_NAME,
     expires: getCookieExpireInDays(),
+    domain: getCookieDomain(),
     defaultCookieContent: {
       opt_in: false,
       version: OilVersion.get(),


### PR DESCRIPTION
This is a rebased pull-request of #244 from @cphilleo.

### The Problem

Multiple sites on sub-domains would like to share consent, e.g. `sub1.example.com`, `sub2.example.com`, `sub3.example.com`. This can be achieved by using the POI feature and specifying a common domain such as `consent.example.com` however there is overhead of at least 20K per page load to use POI.
### Proposal

Since subdomains can set a shared cookie on the parent domain, it's more efficient to allow the SOI cookie to be set on the parent domain, and then be shared by all subdomains. This would be a form of group consent.

This pull request adds an option to set the domain to be used for the SOI cookie. Setting the cookie to an invalid non-parent domain results in no cookie being set.
